### PR TITLE
feat: adding task groups

### DIFF
--- a/oellm/interactive_csv_builder.py
+++ b/oellm/interactive_csv_builder.py
@@ -171,28 +171,51 @@ def build_csv_interactive(output_path: str = "eval_config.csv") -> None:
                 group_choices.append(f"{group_name} - {description}")
 
             selected_groups = questionary.checkbox(
-                "Select task groups to add (use space to select, enter to confirm):",
+                "Select task groups (↑↓ to navigate, SPACE to check/uncheck, ENTER when done):",
                 choices=group_choices,
                 style=custom_style,
+                instruction="Use SPACEBAR to select groups, not typing text",
             ).ask()
 
             if selected_groups is None:
                 console.print("\n[yellow]Cancelled by user.[/yellow]")
                 return
 
-            # Add tasks from selected groups
-            for selection in selected_groups:
-                group_name = selection.split(" - ")[0]
-                group_data = task_groups[group_name]
+            # Only process if groups were actually selected
+            if selected_groups:
+                # Add tasks from selected groups
+                for selection in selected_groups:
+                    group_name = selection.split(" - ")[0]
+                    group_data = task_groups[group_name]
 
-                console.print(f"\n[cyan]Adding tasks from '{group_name}':[/cyan]")
-                for task_item in group_data.get("tasks", []):
-                    task_name = task_item["task"]
-                    n_shots = task_item.get("n_shots", [0])
-                    task_configs.append((task_name, n_shots))
-                    console.print(
-                        f"  [green]✓ Added: {task_name} with n_shot={n_shots}[/green]"
-                    )
+                    console.print(f"\n[cyan]Adding tasks from '{group_name}':[/cyan]")
+                    for task_item in group_data.get("tasks", []):
+                        task_name = task_item["task"]
+                        n_shots = task_item.get("n_shots", [0])
+                        task_configs.append((task_name, n_shots))
+                        console.print(
+                            f"  [green]✓ Added: {task_name} with n_shot={n_shots}[/green]"
+                        )
+
+                # After adding task groups, ask if user wants to add more or proceed
+                proceed_choice = questionary.select(
+                    "\nTask groups added. What would you like to do?",
+                    choices=[
+                        "✅ Continue to preview",
+                        "➕ Add more tasks",
+                    ],
+                    style=custom_style,
+                ).ask()
+
+                if proceed_choice is None:
+                    console.print("\n[yellow]Cancelled by user.[/yellow]")
+                    return
+
+                if proceed_choice == "✅ Continue to preview":
+                    add_more = False
+                # If user chooses "Add more tasks", the loop continues
+            else:
+                console.print("\n[yellow]No task groups selected.[/yellow]")
 
         elif action == "➕ Add a single task":
             # Direct task input

--- a/oellm/task-groups.yaml
+++ b/oellm/task-groups.yaml
@@ -8,45 +8,73 @@ task_groups:
     tasks:
       - task: copa
         n_shots: [0]
+      - task: openbookqa
+        n_shots: [0]
+      - task: lambada_openai
+        n_shots: [0]
+      - task: winogrande
+        n_shots: [0]
       - task: mmlu
         n_shots: [5]
       - task: hellaswag
-        n_shots: [0]
+        n_shots: [10]
       - task: arc_easy
-        n_shots: [0, 5]
+        n_shots: [10]
       - task: arc_challenge
-        n_shots: [0, 5]
-      - task: winogrande
-        n_shots: [0]
-      - task: truthfulqa
-        n_shots: [0]
-      - task: gsm8k
-        n_shots: [5]
+        n_shots: [10]
+      - task: commonsense_qa
+        n_shots: [10]
+      - task: piqa
+        n_shots: [10]
       - task: boolq
-        n_shots: [0]
-      - task: lambada
-        n_shots: [0]
+        n_shots: [10]
 
   belebele-eu:
     description: "Belebele European language tasks"
     tasks:
+      - task: belebele_bul_Cyrl
+        n_shots: [0, 5]
+      - task: belebele_hrv_Latn
+        n_shots: [0, 5]
+      - task: belebele_ces_Latn
+        n_shots: [0, 5]
+      - task: belebele_dan_Latn
+        n_shots: [0, 5]
+      - task: belebele_nld_Latn
+        n_shots: [0, 5]
       - task: belebele_eng_Latn
+        n_shots: [0, 5]
+      - task: belebele_est_Latn
+        n_shots: [0, 5]
+      - task: belebele_fin_Latn
         n_shots: [0, 5]
       - task: belebele_fra_Latn
         n_shots: [0, 5]
       - task: belebele_deu_Latn
         n_shots: [0, 5]
-      - task: belebele_spa_Latn
+      - task: belebele_ell_Grek
+        n_shots: [0, 5]
+      - task: belebele_hun_Latn
         n_shots: [0, 5]
       - task: belebele_ita_Latn
         n_shots: [0, 5]
-      - task: belebele_por_Latn
+      - task: belebele_lvs_Latn
         n_shots: [0, 5]
-      - task: belebele_nld_Latn
+      - task: belebele_lit_Latn
+        n_shots: [0, 5]
+      - task: belebele_mlt_Latn
         n_shots: [0, 5]
       - task: belebele_pol_Latn
         n_shots: [0, 5]
+      - task: belebele_por_Latn
+        n_shots: [0, 5]
       - task: belebele_ron_Latn
+        n_shots: [0, 5]
+      - task: belebele_slk_Latn
+        n_shots: [0, 5]
+      - task: belebele_slv_Latn
+        n_shots: [0, 5]
+      - task: belebele_spa_Latn
         n_shots: [0, 5]
       - task: belebele_swe_Latn
         n_shots: [0, 5]

--- a/oellm/task-groups.yaml
+++ b/oellm/task-groups.yaml
@@ -3,10 +3,12 @@
 # Format: task_name,n_shot1,n_shot2,...
 
 task_groups:
-  open-sci-default:
-    description: "Default OpenEuroLLM scientific tasks"
+  open-sci-0.01:
+    description: "open-sci-ref 0.01 evals"
     tasks:
       - task: copa
+        n_shots: [0]
+      - task: social_iqa
         n_shots: [0]
       - task: openbookqa
         n_shots: [0]
@@ -28,53 +30,52 @@ task_groups:
         n_shots: [10]
       - task: boolq
         n_shots: [10]
-
-  belebele-eu:
+  belebele-eu-5-shot:
     description: "Belebele European language tasks"
     tasks:
       - task: belebele_bul_Cyrl
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_hrv_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_ces_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_dan_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_nld_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_eng_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_est_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_fin_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_fra_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_deu_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_ell_Grek
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_hun_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_ita_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_lvs_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_lit_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_mlt_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_pol_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_por_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_ron_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_slk_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_slv_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_spa_Latn
-        n_shots: [0]
+        n_shots: [5]
       - task: belebele_swe_Latn
-        n_shots: [0]
+        n_shots: [5]

--- a/oellm/task-groups.yaml
+++ b/oellm/task-groups.yaml
@@ -1,0 +1,52 @@
+# Default task groups for interactive CSV builder
+# Each group contains a list of tasks with their n_shot values
+# Format: task_name,n_shot1,n_shot2,...
+
+task_groups:
+  open-sci-default:
+    description: "Default OpenEuroLLM scientific tasks"
+    tasks:
+      - task: copa
+        n_shots: [0]
+      - task: mmlu
+        n_shots: [5]
+      - task: hellaswag
+        n_shots: [0]
+      - task: arc_easy
+        n_shots: [0, 5]
+      - task: arc_challenge
+        n_shots: [0, 5]
+      - task: winogrande
+        n_shots: [0]
+      - task: truthfulqa
+        n_shots: [0]
+      - task: gsm8k
+        n_shots: [5]
+      - task: boolq
+        n_shots: [0]
+      - task: lambada
+        n_shots: [0]
+
+  belebele-eu:
+    description: "Belebele European language tasks"
+    tasks:
+      - task: belebele_eng_Latn
+        n_shots: [0, 5]
+      - task: belebele_fra_Latn
+        n_shots: [0, 5]
+      - task: belebele_deu_Latn
+        n_shots: [0, 5]
+      - task: belebele_spa_Latn
+        n_shots: [0, 5]
+      - task: belebele_ita_Latn
+        n_shots: [0, 5]
+      - task: belebele_por_Latn
+        n_shots: [0, 5]
+      - task: belebele_nld_Latn
+        n_shots: [0, 5]
+      - task: belebele_pol_Latn
+        n_shots: [0, 5]
+      - task: belebele_ron_Latn
+        n_shots: [0, 5]
+      - task: belebele_swe_Latn
+        n_shots: [0, 5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "uv_build"
 [tool.uv.build-backend]
 module-name = "oellm"
 module-root = ""
-include = ["oellm/clusters.yaml"]
+include = ["oellm/clusters.yaml", "oellm/task-groups.yaml"]
 
 [tool.uv.sources]
 torch = [


### PR DESCRIPTION
this adds default task groups that can be used when using the interactive eval csv builder workflow. 

The task groups can be found in `oellm/task-groups.yaml`