### PR TITLE
`--local` not working on compute nodes without internet access

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ Override cluster defaults (partition, account, time limit, etc.) with `--slurm_t
 ```bash
 # Use a different partition (e.g. dev-g on LUMI when small-g is crowded)
 oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
-  --slurm_template_var '{"partition":"dev-g"}'
+  --slurm_template_var '{"PARTITION":"dev-g"}'
 
-# Multiple overrides: partition, account, and time limit
+# Multiple overrides: partition, account, time limit, GPUs
 oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
-  --slurm_template_var '{"partition":"dev-g","account":"myproject","time":"02:00:00"}'
+  --slurm_template_var '{"PARTITION":"dev-g","ACCOUNT":"myproject","TIME":"02:00:00","GPUS_PER_NODE":2}'
 ```
 
-Supported keys: `partition`, `account`, `gpus_per_node`, `time` (HH:MM:SS). Unknown keys set environment variables for the template.
+Use exact env var names: `PARTITION`, `ACCOUNT`, `GPUS_PER_NODE`. `TIME` (HH:MM:SS) overrides the time limit.
 
 ## ⚠️ Dataset Pre-Download Warning
 

--- a/README.md
+++ b/README.md
@@ -69,19 +69,19 @@ oellm schedule-eval --models "model-name" --task_groups "oellm-multilingual"
 
 ## SLURM Overrides
 
-Override cluster defaults (partition, account, time limit, etc.) with `--slurm_opt`:
+Override cluster defaults (partition, account, time limit, etc.) with `--slurm_template_var` (JSON object):
 
 ```bash
 # Use a different partition (e.g. dev-g on LUMI when small-g is crowded)
 oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
-  --slurm_opt "partition=dev-g"
+  --slurm_template_var '{"partition":"dev-g"}'
 
 # Multiple overrides: partition, account, and time limit
 oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
-  --slurm_opt "partition=dev-g,account=myproject,time=02:00:00"
+  --slurm_template_var '{"partition":"dev-g","account":"myproject","time":"02:00:00"}'
 ```
 
-Supported keys: `partition`, `account`, `time` (HH:MM:SS). Unknown keys set environment variables for the template.
+Supported keys: `partition`, `account`, `gpus_per_node`, `time` (HH:MM:SS). Unknown keys set environment variables for the template.
 
 ## ⚠️ Dataset Pre-Download Warning
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ oellm schedule-eval \
 
 Results are written to `./oellm-output/<timestamp>/results/`.
 
+**Air-gapped cluster nodes (no internet):** batch jobs set `HF_HUB_OFFLINE=1` and get `HF_HOME` from your cluster env. With `--local`, the CLI defaults `HF_HOME` to `~/.cache/huggingface` if unset and would otherwise allow Hub access—so on a compute node without network, export your real cache and offline flag before running, for example:
+
+```bash
+export HF_HOME=/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/hf_data
+export HF_HUB_OFFLINE=1
+oellm schedule-eval ... --venv_path .venv --local true
+```
+
+The `HF_HUB_OFFLINE` value is read when you invoke `oellm` and baked into the generated script.
+
 ## SLURM Overrides
 
 Override cluster defaults (partition, account, time limit, etc.) with `--slurm_template_var` (JSON object):

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ oellm schedule-eval --models "model-name" --task_groups "belebele-eu-5-shot,glob
 oellm schedule-eval --models "model-name" --task_groups "oellm-multilingual"
 ```
 
+## SLURM Overrides
+
+Override cluster defaults (partition, account, time limit, etc.) with `--slurm_opt`:
+
+```bash
+# Use a different partition (e.g. dev-g on LUMI when small-g is crowded)
+oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
+  --slurm_opt "partition=dev-g"
+
+# Multiple overrides: partition, account, and time limit
+oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
+  --slurm_opt "partition=dev-g,account=myproject,time=02:00:00"
+```
+
+Supported keys: `partition`, `account`, `time` (HH:MM:SS). Unknown keys set environment variables for the template.
+
 ## ⚠️ Dataset Pre-Download Warning
 
 **Datasets are only automatically pre-downloaded for tasks defined in [`task-groups.yaml`](oellm/resources/task-groups.yaml).**

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -308,6 +308,7 @@ def schedule_evals(
         for key, value in opts.items():
             if not isinstance(value, str):
                 value = str(value)
+            value = value.strip()
             key_lower = key.strip().lower()
             if key_lower == "time":
                 time_limit = value

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import math
 import os
@@ -54,7 +55,7 @@ def schedule_evals(
     skip_checks: bool = False,
     trust_remote_code: bool = True,
     venv_path: str | None = None,
-    slurm_opt: str | None = None,
+    slurm_template_var: str | None = None,
 ) -> None:
     """
     Schedule evaluation jobs for a given set of models, tasks, and number of shots.
@@ -86,9 +87,9 @@ def schedule_evals(
         trust_remote_code: If True, trust remote code when downloading datasets. Default is True. Workflow might fail if set to False.
         venv_path: Path to a Python virtual environment. If provided, evaluations run directly using
             this venv instead of inside a Singularity/Apptainer container.
-        slurm_opt: Comma-separated KEY=VALUE overrides for SLURM/template variables.
-            Example: "partition=dev-g,account=FOO,time=02:00:00"
-            Keys: partition, account, gpus_per_node, time (HH:MM:SS). Unknown keys set env vars.
+        slurm_template_var: JSON object of template variable overrides. Keys map to env vars
+            (partition→PARTITION, account→ACCOUNT, etc.); "time" overrides the time limit.
+            Example: '{"partition":"dev-g","account":"FOO","time":"02:00:00"}'
     """
     _setup_logging(verbose)
 
@@ -291,29 +292,30 @@ def schedule_evals(
     computed_time = f"{hours_with_margin:02d}:59:00"
     time_limit = computed_time
 
-    # Apply slurm_opt overrides (space-separated KEY=VALUE pairs)
-    _SLURM_OPT_ENV_MAP = {
-        "partition": "PARTITION",
-        "account": "ACCOUNT",
-        "gpus_per_node": "GPUS_PER_NODE",
-    }
-    if slurm_opt:
-        opts = [p.strip() for p in slurm_opt.split(",") if p.strip()]
-        for opt in opts:
-            if "=" not in opt:
-                raise ValueError(
-                    f"slurm_opt must be KEY=VALUE pairs, got: {opt!r}"
-                )
-            key, _, value = opt.partition("=")
+    # Apply slurm_template_var overrides (JSON object)
+    if slurm_template_var:
+        try:
+            opts = json.loads(slurm_template_var)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"slurm_template_var must be a valid JSON object: {e}"
+            ) from e
+        if not isinstance(opts, dict):
+            raise ValueError(
+                "slurm_template_var must be a JSON object, e.g. "
+                '{"partition":"dev-g","account":"FOO"}'
+            )
+        for key, value in opts.items():
+            if not isinstance(value, str):
+                value = str(value)
             key_lower = key.strip().lower()
-            value = value.strip()
             if key_lower == "time":
                 time_limit = value
                 logging.info(f"Using time limit override: {value}")
             else:
-                env_key = _SLURM_OPT_ENV_MAP.get(key_lower, key.strip().upper())
+                env_key = key.strip().upper()
                 os.environ[env_key] = value
-                logging.info(f"Using slurm_opt override: {env_key}={value}")
+                logging.info(f"Using slurm_template_var override: {env_key}={value}")
 
     # Log the calculated values
     logging.info("📊 Evaluation planning:")
@@ -553,7 +555,7 @@ def collect_results(
                         "task": group_name,
                         "n_shot": n_shot,
                         "performance": performance,
-                        "metric_name": metric_name or "",
+                        "metric_name": metric_name if metric_name is not None else "",
                     }
                 )
                 # Skip per-task iteration when groups are present
@@ -620,7 +622,7 @@ def collect_results(
                         "task": task_name,
                         "n_shot": n_shot,
                         "performance": performance,
-                        "metric_name": metric_name or "",
+                        "metric_name": metric_name if metric_name is not None else "",
                     }
                 )
             else:

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -31,6 +31,21 @@ from oellm.utils import (
 )
 
 
+def _resolve_hf_hub_offline(local: bool) -> int:
+    """Value embedded in the generated eval script as HF_HUB_OFFLINE.
+
+    If ``HF_HUB_OFFLINE`` is set in the environment when ``oellm`` runs, that
+    value wins. Otherwise defaults to online Hub access for ``--local``
+    (typical laptop dev) and offline for SLURM jobs (air-gapped workers).
+    """
+    raw = os.environ.get("HF_HUB_OFFLINE")
+    if raw is not None and str(raw).strip() != "":
+        try:
+            return int(str(raw).strip())
+        except ValueError:
+            logging.warning("Invalid HF_HUB_OFFLINE=%r; using default", raw)
+    return 0 if local else 1
+
 @dataclass
 class EvaluationJob:
     model_path: Path | str
@@ -369,7 +384,7 @@ def schedule_evals(
         venv_path=venv_path or "",
         lm_eval_include_path=lm_eval_include_path
         or str(files("oellm.resources") / "custom_lm_eval_tasks"),
-        hf_hub_offline=0 if local else 1,
+        hf_hub_offline=_resolve_hf_hub_offline(local),
         lighteval_model_args="trust_remote_code=True,batch_size=1"
         if local
         else "trust_remote_code=True",

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -54,6 +54,8 @@ def schedule_evals(
     skip_checks: bool = False,
     trust_remote_code: bool = True,
     venv_path: str | None = None,
+    partition: str | None = None,
+    time_limit: str | None = None,
 ) -> None:
     """
     Schedule evaluation jobs for a given set of models, tasks, and number of shots.
@@ -85,6 +87,10 @@ def schedule_evals(
         trust_remote_code: If True, trust remote code when downloading datasets. Default is True. Workflow might fail if set to False.
         venv_path: Path to a Python virtual environment. If provided, evaluations run directly using
             this venv instead of inside a Singularity/Apptainer container.
+        partition: Override the SLURM partition (e.g. dev-g on LUMI when small-g is crowded).
+            Defaults to the cluster config from clusters.yaml.
+        time_limit: Override the SLURM time limit in HH:MM:SS format (e.g. 02:00:00).
+            Defaults to an auto-computed value based on eval count.
     """
     _setup_logging(verbose)
 
@@ -284,7 +290,15 @@ def schedule_evals(
     hours_with_margin = max(1, int(math.ceil(minutes_with_margin / 60)))
     hours_with_margin = max(hours_with_margin, 3)
     hours_with_margin = min(hours_with_margin, 23)
-    time_limit = f"{hours_with_margin:02d}:59:00"
+    computed_time = f"{hours_with_margin:02d}:59:00"
+    time_limit = time_limit if time_limit is not None else computed_time
+    if time_limit != computed_time:
+        logging.info(f"Using time limit override: {time_limit}")
+
+    # Override partition if specified
+    if partition is not None:
+        os.environ["PARTITION"] = partition
+        logging.info(f"Using partition override: {partition}")
 
     # Log the calculated values
     logging.info("📊 Evaluation planning:")
@@ -397,18 +411,43 @@ def collect_results(
         _tg_cfg = yaml.safe_load(_f)
     task_metrics = _tg_cfg.get("task_metrics", {})
 
-    def _resolve_metric(task_name: str, result_dict: dict) -> float | None:
-        """Return the preferred metric value for task_name from result_dict."""
+    def _resolve_metric(task_name: str, result_dict: dict) -> tuple[float | None, str | None]:
+        """Return (value, metric_name) for task_name from result_dict."""
+        # Skip non-metric keys; lm-eval uses suffixes like ",none" or ",remove_whitespace"
+        def _first_numeric(d: dict, *candidates: str) -> tuple[float | None, str | None]:
+            for c in candidates:
+                if c in d and isinstance(d[c], (int, float)):
+                    return float(d[c]), c
+            return None, None
+
+        def _first_matching_prefix(d: dict, prefix: str) -> tuple[float | None, str | None]:
+            for k, v in d.items():
+                if (k == prefix or k.startswith(prefix + ",")) and isinstance(
+                    v, (int, float)
+                ):
+                    return float(v), k
+            return None, None
+
         preferred = task_metrics.get(task_name)
         if preferred is not None:
-            val = result_dict.get(f"{preferred},none")
-            if val is None:
-                val = result_dict.get(preferred)
-            return val
+            val, key = _first_numeric(
+                result_dict, f"{preferred},none", preferred
+            )
+            if val is not None:
+                return val, key
+            val, key = _first_matching_prefix(result_dict, preferred)
+            return val, key
+
         for metric in ["acc,none", "acc", "accuracy", "f1", "exact_match"]:
-            if metric in result_dict:
-                return result_dict[metric]
-        return None
+            val, key = _first_numeric(result_dict, metric)
+            if val is not None:
+                return val, key
+            val, key = _first_matching_prefix(
+                result_dict, metric.split(",")[0]
+            )
+            if val is not None:
+                return val, key
+        return None, None
 
     results_path = Path(results_dir)
     if not results_path.exists():
@@ -489,7 +528,7 @@ def collect_results(
                         break
             if n_shot == "unknown" and global_n_shot is not None:
                 n_shot = global_n_shot
-            performance = _resolve_metric(group_name, group_results)
+            performance, metric_name = _resolve_metric(group_name, group_results)
             if performance is not None:
                 if check:
                     completed_jobs.add((model_name, group_name, n_shot))
@@ -499,6 +538,7 @@ def collect_results(
                         "task": group_name,
                         "n_shot": n_shot,
                         "performance": performance,
+                        "metric_name": metric_name or "",
                     }
                 )
                 # Skip per-task iteration when groups are present
@@ -552,7 +592,7 @@ def collect_results(
                     n_shot = global_n_shot
 
             # Get the primary metric (usually acc, acc_norm)
-            performance = _resolve_metric(task_name, task_results)
+            performance, metric_name = _resolve_metric(task_name, task_results)
 
             if performance is not None:
                 # Track completed job for check mode
@@ -565,6 +605,7 @@ def collect_results(
                         "task": task_name,
                         "n_shot": n_shot,
                         "performance": performance,
+                        "metric_name": metric_name or "",
                     }
                 )
             else:

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -46,6 +46,7 @@ def _resolve_hf_hub_offline(local: bool) -> int:
             logging.warning("Invalid HF_HUB_OFFLINE=%r; using default", raw)
     return 0 if local else 1
 
+
 @dataclass
 class EvaluationJob:
     model_path: Path | str

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -54,8 +54,7 @@ def schedule_evals(
     skip_checks: bool = False,
     trust_remote_code: bool = True,
     venv_path: str | None = None,
-    partition: str | None = None,
-    time_limit: str | None = None,
+    slurm_opt: str | None = None,
 ) -> None:
     """
     Schedule evaluation jobs for a given set of models, tasks, and number of shots.
@@ -87,10 +86,9 @@ def schedule_evals(
         trust_remote_code: If True, trust remote code when downloading datasets. Default is True. Workflow might fail if set to False.
         venv_path: Path to a Python virtual environment. If provided, evaluations run directly using
             this venv instead of inside a Singularity/Apptainer container.
-        partition: Override the SLURM partition (e.g. dev-g on LUMI when small-g is crowded).
-            Defaults to the cluster config from clusters.yaml.
-        time_limit: Override the SLURM time limit in HH:MM:SS format (e.g. 02:00:00).
-            Defaults to an auto-computed value based on eval count.
+        slurm_opt: Space-separated KEY=VALUE overrides for SLURM/template variables.
+            Example: "partition=dev-g account=FOO time=02:00:00"
+            Keys: partition, account, gpus_per_node, time (HH:MM:SS). Unknown keys set env vars.
     """
     _setup_logging(verbose)
 
@@ -291,14 +289,31 @@ def schedule_evals(
     hours_with_margin = max(hours_with_margin, 3)
     hours_with_margin = min(hours_with_margin, 23)
     computed_time = f"{hours_with_margin:02d}:59:00"
-    time_limit = time_limit if time_limit is not None else computed_time
-    if time_limit != computed_time:
-        logging.info(f"Using time limit override: {time_limit}")
+    time_limit = computed_time
 
-    # Override partition if specified
-    if partition is not None:
-        os.environ["PARTITION"] = partition
-        logging.info(f"Using partition override: {partition}")
+    # Apply slurm_opt overrides (space-separated KEY=VALUE pairs)
+    _SLURM_OPT_ENV_MAP = {
+        "partition": "PARTITION",
+        "account": "ACCOUNT",
+        "gpus_per_node": "GPUS_PER_NODE",
+    }
+    if slurm_opt:
+        opts = [p for p in slurm_opt.split() if p]
+        for opt in opts:
+            if "=" not in opt:
+                raise ValueError(
+                    f"slurm_opt must be KEY=VALUE pairs, got: {opt!r}"
+                )
+            key, _, value = opt.partition("=")
+            key_lower = key.strip().lower()
+            value = value.strip()
+            if key_lower == "time":
+                time_limit = value
+                logging.info(f"Using time limit override: {value}")
+            else:
+                env_key = _SLURM_OPT_ENV_MAP.get(key_lower, key.strip().upper())
+                os.environ[env_key] = value
+                logging.info(f"Using slurm_opt override: {env_key}={value}")
 
     # Log the calculated values
     logging.info("📊 Evaluation planning:")

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -86,8 +86,8 @@ def schedule_evals(
         trust_remote_code: If True, trust remote code when downloading datasets. Default is True. Workflow might fail if set to False.
         venv_path: Path to a Python virtual environment. If provided, evaluations run directly using
             this venv instead of inside a Singularity/Apptainer container.
-        slurm_opt: Space-separated KEY=VALUE overrides for SLURM/template variables.
-            Example: "partition=dev-g account=FOO time=02:00:00"
+        slurm_opt: Comma-separated KEY=VALUE overrides for SLURM/template variables.
+            Example: "partition=dev-g,account=FOO,time=02:00:00"
             Keys: partition, account, gpus_per_node, time (HH:MM:SS). Unknown keys set env vars.
     """
     _setup_logging(verbose)
@@ -298,7 +298,7 @@ def schedule_evals(
         "gpus_per_node": "GPUS_PER_NODE",
     }
     if slurm_opt:
-        opts = [p for p in slurm_opt.split() if p]
+        opts = [p.strip() for p in slurm_opt.split(",") if p.strip()]
         for opt in opts:
             if "=" not in opt:
                 raise ValueError(

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -87,9 +87,9 @@ def schedule_evals(
         trust_remote_code: If True, trust remote code when downloading datasets. Default is True. Workflow might fail if set to False.
         venv_path: Path to a Python virtual environment. If provided, evaluations run directly using
             this venv instead of inside a Singularity/Apptainer container.
-        slurm_template_var: JSON object of template variable overrides. Keys map to env vars
-            (partition→PARTITION, account→ACCOUNT, etc.); "time" overrides the time limit.
-            Example: '{"partition":"dev-g","account":"FOO","time":"02:00:00"}'
+        slurm_template_var: JSON object of template variable overrides. Use exact env var names
+            (PARTITION, ACCOUNT, GPUS_PER_NODE). "TIME" overrides the time limit.
+            Example: '{"PARTITION":"dev-g","ACCOUNT":"FOO","TIME":"02:00:00","GPUS_PER_NODE":2}'
     """
     _setup_logging(verbose)
 
@@ -303,20 +303,15 @@ def schedule_evals(
         if not isinstance(opts, dict):
             raise ValueError(
                 "slurm_template_var must be a JSON object, e.g. "
-                '{"partition":"dev-g","account":"FOO"}'
+                '{"PARTITION":"dev-g","ACCOUNT":"FOO","TIME":"02:00:00"}'
             )
         for key, value in opts.items():
-            if not isinstance(value, str):
-                value = str(value)
-            value = value.strip()
-            key_lower = key.strip().lower()
-            if key_lower == "time":
-                time_limit = value
-                logging.info(f"Using time limit override: {value}")
+            if key.upper() == "TIME":
+                time_limit = str(value)
+                logging.info(f"Using time limit override: {time_limit}")
             else:
-                env_key = key.strip().upper()
-                os.environ[env_key] = value
-                logging.info(f"Using slurm_template_var override: {env_key}={value}")
+                os.environ[key] = str(value)
+                logging.info(f"Using slurm_template_var override: {key}={value}")
 
     # Log the calculated values
     logging.info("📊 Evaluation planning:")
@@ -429,8 +424,11 @@ def collect_results(
         _tg_cfg = yaml.safe_load(_f)
     task_metrics = _tg_cfg.get("task_metrics", {})
 
-    def _resolve_metric(task_name: str, result_dict: dict) -> tuple[float | None, str | None]:
+    def _resolve_metric(
+        task_name: str, result_dict: dict
+    ) -> tuple[float | None, str | None]:
         """Return (value, metric_name) for task_name from result_dict."""
+
         # Skip non-metric keys; lm-eval uses suffixes like ",none" or ",remove_whitespace"
         def _first_numeric(d: dict, *candidates: str) -> tuple[float | None, str | None]:
             for c in candidates:
@@ -438,7 +436,9 @@ def collect_results(
                     return float(d[c]), c
             return None, None
 
-        def _first_matching_prefix(d: dict, prefix: str) -> tuple[float | None, str | None]:
+        def _first_matching_prefix(
+            d: dict, prefix: str
+        ) -> tuple[float | None, str | None]:
             for k, v in d.items():
                 if (k == prefix or k.startswith(prefix + ",")) and isinstance(
                     v, (int, float)
@@ -448,9 +448,7 @@ def collect_results(
 
         preferred = task_metrics.get(task_name)
         if preferred is not None:
-            val, key = _first_numeric(
-                result_dict, f"{preferred},none", preferred
-            )
+            val, key = _first_numeric(result_dict, f"{preferred},none", preferred)
             if val is not None:
                 return val, key
             val, key = _first_matching_prefix(result_dict, preferred)
@@ -460,9 +458,7 @@ def collect_results(
             val, key = _first_numeric(result_dict, metric)
             if val is not None:
                 return val, key
-            val, key = _first_matching_prefix(
-                result_dict, metric.split(",")[0]
-            )
+            val, key = _first_matching_prefix(result_dict, metric.split(",")[0])
             if val is not None:
                 return val, key
         return None, None

--- a/tests/test_schedule_evals.py
+++ b/tests/test_schedule_evals.py
@@ -31,8 +31,8 @@ def test_schedule_evals(tmp_path, n_shot, task_groups):
         )
 
 
-def test_schedule_evals_slurm_opt_overrides(tmp_path):
-    """Verify --slurm_opt space-separated KEY=VALUE overrides appear in the generated sbatch."""
+def test_schedule_evals_slurm_template_var_overrides(tmp_path):
+    """Verify --slurm_template_var JSON overrides appear in the generated sbatch."""
     with (
         patch("oellm.main._load_cluster_env"),
         patch("oellm.main._num_jobs_in_queue", return_value=0),
@@ -52,7 +52,7 @@ def test_schedule_evals_slurm_opt_overrides(tmp_path):
             skip_checks=True,
             venv_path=str(Path(sys.prefix)),
             dry_run=True,
-            slurm_opt="partition=dev-g,account=myproject,time=02:15:00",
+            slurm_template_var='{"partition":"dev-g","account":"myproject","time":"02:15:00"}',
         )
 
     sbatch_files = list(tmp_path.glob("**/submit_evals.sbatch"))
@@ -61,3 +61,32 @@ def test_schedule_evals_slurm_opt_overrides(tmp_path):
     assert "#SBATCH --partition=dev-g" in sbatch_content
     assert "#SBATCH --account=myproject" in sbatch_content
     assert "#SBATCH --time=02:15:00" in sbatch_content
+
+
+def test_schedule_evals_slurm_template_var_invalid_json(tmp_path):
+    """Verify invalid slurm_template_var raises ValueError."""
+    with (
+        patch("oellm.main._load_cluster_env"),
+        patch("oellm.main._num_jobs_in_queue", return_value=0),
+        patch.dict(os.environ, {"EVAL_OUTPUT_DIR": str(tmp_path)}),
+    ):
+        with pytest.raises(ValueError, match="valid JSON object"):
+            schedule_evals(
+                models="EleutherAI/pythia-70m",
+                tasks="hellaswag",
+                n_shot=0,
+                skip_checks=True,
+                venv_path=str(Path(sys.prefix)),
+                dry_run=True,
+                slurm_template_var="not valid json",
+            )
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            schedule_evals(
+                models="EleutherAI/pythia-70m",
+                tasks="hellaswag",
+                n_shot=0,
+                skip_checks=True,
+                venv_path=str(Path(sys.prefix)),
+                dry_run=True,
+                slurm_template_var='["partition", "dev-g"]',
+            )

--- a/tests/test_schedule_evals.py
+++ b/tests/test_schedule_evals.py
@@ -31,8 +31,8 @@ def test_schedule_evals(tmp_path, n_shot, task_groups):
         )
 
 
-def test_schedule_evals_partition_and_time_overrides(tmp_path):
-    """Verify --partition and --time_limit overrides appear in the generated sbatch."""
+def test_schedule_evals_slurm_opt_overrides(tmp_path):
+    """Verify --slurm_opt space-separated KEY=VALUE overrides appear in the generated sbatch."""
     with (
         patch("oellm.main._load_cluster_env"),
         patch("oellm.main._num_jobs_in_queue", return_value=0),
@@ -52,12 +52,12 @@ def test_schedule_evals_partition_and_time_overrides(tmp_path):
             skip_checks=True,
             venv_path=str(Path(sys.prefix)),
             dry_run=True,
-            partition="dev-g",
-            time_limit="01:30:00",
+            slurm_opt="partition=dev-g account=myproject time=02:15:00",
         )
 
     sbatch_files = list(tmp_path.glob("**/submit_evals.sbatch"))
     assert len(sbatch_files) == 1
     sbatch_content = sbatch_files[0].read_text()
     assert "#SBATCH --partition=dev-g" in sbatch_content
-    assert "#SBATCH --time=01:30:00" in sbatch_content
+    assert "#SBATCH --account=myproject" in sbatch_content
+    assert "#SBATCH --time=02:15:00" in sbatch_content

--- a/tests/test_schedule_evals.py
+++ b/tests/test_schedule_evals.py
@@ -52,7 +52,7 @@ def test_schedule_evals_slurm_opt_overrides(tmp_path):
             skip_checks=True,
             venv_path=str(Path(sys.prefix)),
             dry_run=True,
-            slurm_opt="partition=dev-g account=myproject time=02:15:00",
+            slurm_opt="partition=dev-g,account=myproject,time=02:15:00",
         )
 
     sbatch_files = list(tmp_path.glob("**/submit_evals.sbatch"))

--- a/tests/test_schedule_evals.py
+++ b/tests/test_schedule_evals.py
@@ -52,7 +52,7 @@ def test_schedule_evals_slurm_template_var_overrides(tmp_path):
             skip_checks=True,
             venv_path=str(Path(sys.prefix)),
             dry_run=True,
-            slurm_template_var='{"partition":"dev-g","account":"myproject","time":"02:15:00"}',
+            slurm_template_var='{"PARTITION":"dev-g","ACCOUNT":"myproject","TIME":"02:15:00","GPUS_PER_NODE":2}',
         )
 
     sbatch_files = list(tmp_path.glob("**/submit_evals.sbatch"))
@@ -61,6 +61,7 @@ def test_schedule_evals_slurm_template_var_overrides(tmp_path):
     assert "#SBATCH --partition=dev-g" in sbatch_content
     assert "#SBATCH --account=myproject" in sbatch_content
     assert "#SBATCH --time=02:15:00" in sbatch_content
+    assert "#SBATCH --gres=gpu:2" in sbatch_content
 
 
 def test_schedule_evals_slurm_template_var_invalid_json(tmp_path):

--- a/tests/test_schedule_evals.py
+++ b/tests/test_schedule_evals.py
@@ -29,3 +29,35 @@ def test_schedule_evals(tmp_path, n_shot, task_groups):
             venv_path=str(Path(sys.prefix)),
             dry_run=True,
         )
+
+
+def test_schedule_evals_partition_and_time_overrides(tmp_path):
+    """Verify --partition and --time_limit overrides appear in the generated sbatch."""
+    with (
+        patch("oellm.main._load_cluster_env"),
+        patch("oellm.main._num_jobs_in_queue", return_value=0),
+        patch.dict(
+            os.environ,
+            {
+                "EVAL_OUTPUT_DIR": str(tmp_path),
+                "PARTITION": "default_partition",
+                "ACCOUNT": "test_account",
+            },
+        ),
+    ):
+        schedule_evals(
+            models="EleutherAI/pythia-70m",
+            tasks="hellaswag",
+            n_shot=0,
+            skip_checks=True,
+            venv_path=str(Path(sys.prefix)),
+            dry_run=True,
+            partition="dev-g",
+            time_limit="01:30:00",
+        )
+
+    sbatch_files = list(tmp_path.glob("**/submit_evals.sbatch"))
+    assert len(sbatch_files) == 1
+    sbatch_content = sbatch_files[0].read_text()
+    assert "#SBATCH --partition=dev-g" in sbatch_content
+    assert "#SBATCH --time=01:30:00" in sbatch_content


### PR DESCRIPTION
Fix to use local venv on Leonardo interactive compute nodes that do not have internet connectivity.

Error message:
```
(oellm) (base) [shaldar0@lrdn1717 oellm-cli]$ oellm schedule-eval     --models "EleutherAI/pythia-160m"     --tasks "gsm8k"     --n_shot 0     --venv_path .venv     --local true     --limit 1


22:48:53 INFO     Using Python virtual environment at .venv                                                                                                                                   


22:48:54 INFO     Model EleutherAI/pythia-160m not found locally, assuming it is a 🤗 hub model                                                                                               
Using the latest cached version of the dataset since openai/gsm8k couldn't be found on the Hugging Face Hub (offline mode is enabled).
         WARNING  Using the latest cached version of the dataset since openai/gsm8k couldn't be found on the Hugging Face Hub (offline mode is enabled).                                      
⠋ Downloading 'openai/gsm8k/main' (1/1)Found the latest cached dataset configuration 'main' at /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/hf_data/datasets/openai___gsm8k/main/0.0.0/cc7b047b6e5bb11b4f1af84efc572db110a51b3c (last modified on Tue Feb 10 14:42:32 2026).
         WARNING  Found the latest cached dataset configuration 'main' at                                                                                                                     
                  /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/hf_data/datasets/openai___gsm8k/main/0.0.0/cc7b047b6e5bb11b4f1af84efc572db110a51b3c (last modified on Tue Feb 10   
                  14:42:32 2026).                                                                                                                                                             
22:48:55 INFO     Shuffled evaluation jobs for even load distribution across array workers                                                                                                    
         INFO     📊 Evaluation planning:                                                                                                                                                     
         INFO        Total evaluations: 1                                                                                                                                                     
         INFO        Estimated time per eval: 10 minutes                                                                                                                                      
         INFO        Total estimated time: 10 minutes (0.2 hours)                                                                                                                             
         INFO        Desired array size: 1                                                                                                                                                    
         INFO        Actual array size: 1 (limited by queue capacity: 1)                                                                                                                      
         INFO        Evaluations per job: 1                                                                                                                                                   
         INFO        Time per job: 10 minutes (0.2 hours)                                                                                                                                     
         INFO        Time limit with safety margin: 03:59:00                                                                                                                                  
         INFO     📁 Evaluation directory: /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/outputs/2026-04-09-22-48-55                                                               
         INFO     📄 Script: /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/outputs/2026-04-09-22-48-55/submit_evals.sbatch                                                         
         INFO     📋 Job configuration: /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/outputs/2026-04-09-22-48-55/jobs.csv                                                         
         INFO     📊 Results will be stored in: /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/outputs/2026-04-09-22-48-55/results                                                  
         INFO     Running evaluations locally with bash...                                                                                                                                    
Running eval on /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/outputs/2026-04-09-22-48-55/jobs.csv with 1 array jobs distributing 1 evaluations
SLURM_JOB_ID: 39523302
SLURM_ARRAY_JOB_ID: 0
SLURM_ARRAY_TASK_ID: 0
This job (array task 0) will process evaluations from index 1 to 1.
Each array job handles approximately 1 evaluations.
----------------------------------------------------
Starting evaluation for:
  Model: EleutherAI/pythia-160m
  Task: gsm8k
  N-shot: 0
  Suite: lm_eval
----------------------------------------------------
2026-04-09:22:48:55 WARNING  [config.evaluate_config:281] --limit SHOULD ONLY BE USED FOR TESTING. REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT.
2026-04-09:22:49:10 INFO     [_cli.run:375] Including path: /leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/oellm/resources/custom_lm_eval_tasks
2026-04-09:22:49:10 INFO     [_cli.run:376] Selected Tasks: ['gsm8k']
2026-04-09:22:49:15 INFO     [evaluator:211] Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234 | Setting fewshot manual seed to 1234
2026-04-09:22:49:15 INFO     [evaluator:236] Initializing hf model, with arguments: {'pretrained': 'EleutherAI/pythia-160m', 'trust_remote_code': True}
[RANK 0] Detected kernel version 4.18.0, which is below the recommended minimum of 5.5.0; this can cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher.
2026-04-09:22:49:22 INFO     [models.huggingface:161] Using device 'cuda:0'
'[Errno 101] Network is unreachable' thrown while requesting HEAD https://huggingface.co/EleutherAI/pythia-160m/resolve/main/vocab.json
Retrying in 1s [Retry 1/5].
Traceback (most recent call last):
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/transformers/tokenization_utils_base.py", line 1690, in from_pretrained
    resolved_vocab_files[file_id] = cached_file(
                                    ^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/transformers/utils/hub.py", line 278, in cached_file
    file = cached_files(path_or_repo_id=path_or_repo_id, filenames=[filename], **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/transformers/utils/hub.py", line 512, in cached_files
    raise e
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/transformers/utils/hub.py", line 422, in cached_files
    hf_hub_download(
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 89, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/file_download.py", line 982, in hf_hub_download
    return _hf_hub_download_to_cache_dir(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/file_download.py", line 1115, in _hf_hub_download_to_cache_dir
    _get_metadata_or_catch_error(
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/file_download.py", line 1649, in _get_metadata_or_catch_error
    metadata = get_hf_file_metadata(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 89, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/file_download.py", line 1572, in get_hf_file_metadata
    response = _httpx_follow_relative_redirects_with_backoff(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_http.py", line 644, in _httpx_follow_relative_redirects_with_backoff
    response = http_backoff(
               ^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_http.py", line 518, in http_backoff
    return next(
           ^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_http.py", line 426, in _http_backoff_base
    response = client.request(method=method, url=url, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/httpx/_client.py", line 825, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/httpx/_client.py", line 901, in send
    raise RuntimeError("Cannot send a request, as the client has been closed.")
RuntimeError: Cannot send a request, as the client has been closed.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/__main__.py", line 14, in <module>
    cli_evaluate()
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/__main__.py", line 10, in cli_evaluate
    parser.execute(args)
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/_cli/harness.py", line 60, in execute
    args.func(args)
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/_cli/run.py", line 379, in _execute
    results = simple_evaluate(
              ^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/utils.py", line 498, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/evaluator.py", line 239, in simple_evaluate
    lm = lm_eval.api.registry.get_model(model).create_from_arg_obj(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/api/model.py", line 180, in create_from_arg_obj
    return cls(**arg_dict, **additional_config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/models/huggingface.py", line 204, in __init__
    self._create_tokenizer(
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/lm_eval/models/huggingface.py", line 793, in _create_tokenizer
    self.tokenizer = transformers.AutoTokenizer.from_pretrained(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/transformers/models/auto/tokenization_auto.py", line 793, in from_pretrained
    return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-cli/.venv/lib/python3.12/site-packages/transformers/tokenization_utils_base.py", line 1709, in from_pretrained
    raise OSError(
OSError: Can't load tokenizer for 'EleutherAI/pythia-160m'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure 'EleutherAI/pythia-160m' is the correct path to a directory containing all relevant files for a GPTNeoXTokenizer tokenizer.
Evaluation finished for model: EleutherAI/pythia-160m
Job 0 finished.
22:50:04 INFO     Local evaluation completed. 
```