### PR TITLE
message in case of stale datasets

### DIFF
--- a/oellm/utils.py
+++ b/oellm/utils.py
@@ -299,6 +299,7 @@ def _process_model_paths(models: Iterable[str]):
                 )
 
 
+
 def _pre_download_datasets_from_specs(
     specs: Iterable, trust_remote_code: bool = True
 ) -> None:
@@ -343,6 +344,18 @@ def _pre_download_datasets_from_specs(
                             trust_remote_code=trust_remote_code,
                         )
                     continue
+                if "Feature type" in str(e) and "not found" in str(e):
+                    hf_datasets_cache = os.environ.get(
+                        "HF_DATASETS_CACHE",
+                        str(Path.home() / ".cache" / "huggingface" / "datasets"),
+                    )
+                    safe_name = spec.repo_id.replace("/", "___")
+                    cache_dir = os.path.join(hf_datasets_cache, safe_name)
+                    raise RuntimeError(
+                        f"Cached metadata for '{label}' is incompatible with the installed "
+                        f"datasets version ('{e}'). Delete the stale cache and re-run:\n\n"
+                        f"    rm -rf {cache_dir}\n"
+                    ) from None
                 raise
 
             logging.debug(f"Finished downloading dataset '{label}'.")

--- a/oellm/utils.py
+++ b/oellm/utils.py
@@ -299,7 +299,6 @@ def _process_model_paths(models: Iterable[str]):
                 )
 
 
-
 def _pre_download_datasets_from_specs(
     specs: Iterable, trust_remote_code: bool = True
 ) -> None:


### PR DESCRIPTION
When changing datasets versions, some datasets are downloaded in the cache and show an error like this:

```
Traceback (most recent call last):
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/bin/oellm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/oellm/main.py", line 767, in main
    auto_cli(
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/jsonargparse/_cli.py", line 132, in auto_cli
    return _run_component(component, init.get(subcommand))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/jsonargparse/_cli.py", line 234, in _run_component
    return component(**cfg)
           ^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/oellm/utils.py", line 446, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/oellm/main.py", line 260, in schedule_evals
    _pre_download_datasets_from_specs(
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/oellm/utils.py", line 322, in _pre_download_datasets_from_specs
    load_dataset(
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/load.py", line 2062, in load_dataset
    builder_instance = load_dataset_builder(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/load.py", line 1819, in load_dataset_builder
    builder_instance: DatasetBuilder = builder_cls(
                                       ^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/builder.py", line 395, in __init__
    self.info = DatasetInfo.from_directory(self._cache_dir)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/info.py", line 279, in from_directory
    return cls.from_dict(dataset_info_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/info.py", line 284, in from_dict
    return cls(**{k: v for k, v in dataset_info_dict.items() if k in field_names})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 20, in __init__
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/info.py", line 170, in __post_init__
    self.features = Features.from_dict(self.features)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/features/features.py", line 1888, in from_dict
    obj = generate_from_dict(dic)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/features/features.py", line 1468, in generate_from_dict
    return {key: generate_from_dict(value) for key, value in obj.items()}
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salinasd/Documents/code/multisynt-evals/oellm-cli/.venv/lib/python3.12/site-packages/datasets/features/features.py", line 1474, in generate_from_dict
    raise ValueError(f"Feature type '{_type}' not found. Available feature types: {list(_FEATURE_TYPES.keys())}")
ValueError: Feature type 'List' not found. Available feature types: ['Value', 'ClassLabel', 'Translation', 'TranslationVariableLanguages', 'LargeList', 'Sequence', 'Array2D', 'Array3D', 'Array4D', 'Array5D', 'Audio', 'Image', 'Video', 'Pdf']
```

The solution is to delete the cache, this PR adds a message to propose this solution to the user (it does not run the delete to avoid any potential mistake).