### PR TITLE
Enable belebele_cf on Leonardo + SLURM memory request + lighteval batch‑size defaults + enable `collect-results` for belebele_cf

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,43 @@ The `HF_HUB_OFFLINE` value is read when you invoke `oellm` and baked into the ge
 
 ## SLURM Overrides
 
-Override cluster defaults (partition, account, time limit, etc.) with `--slurm_template_var` (JSON object):
+Override cluster defaults (partition, account, time limit, memory, etc.) with `--slurm_template_var` (JSON object). By default, generated jobs request host RAM as `GPUS_PER_NODE * SLURM_MEM_PER_GPU_GB`, plus `LIGHTEVAL_EXTRA_MEM_GB` for lighteval runs. You can force an exact value with `SLURM_MEM`.
 
 ```bash
 # Use a different partition (e.g. dev-g on LUMI when small-g is crowded)
 oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
   --slurm_template_var '{"PARTITION":"dev-g"}'
 
-# Multiple overrides: partition, account, time limit, GPUs
+# Multiple overrides: partition, account, time limit, GPUs, exact RAM
 oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
-  --slurm_template_var '{"PARTITION":"dev-g","ACCOUNT":"myproject","TIME":"02:00:00","GPUS_PER_NODE":2}'
+  --slurm_template_var '{"PARTITION":"dev-g","ACCOUNT":"myproject","TIME":"02:00:00","GPUS_PER_NODE":2,"SLURM_MEM":"96G"}'
 ```
 
-Use exact env var names: `PARTITION`, `ACCOUNT`, `GPUS_PER_NODE`. `TIME` (HH:MM:SS) overrides the time limit.
+Use exact env var names: `PARTITION`, `ACCOUNT`, `GPUS_PER_NODE`, `SLURM_MEM`. `TIME` (HH:MM:SS) overrides the time limit.
+
+## Lighteval Batch Size
+
+For lighteval runs, generated jobs now default to `batch_size=1` for local runs and
+`batch_size=32` for non-local (SLURM/cluster) runs. This reduces the risk of
+out-of-memory failures where lighteval's auto batch-size detection can be
+overly optimistic for multiple-choice loglikelihood tasks. You can still
+override these defaults:
+
+```bash
+# Set an explicit batch size (overrides the local/cluster default)
+LIGHTEVAL_BATCH_SIZE=8 oellm schedule-eval \
+  --models "model-name" \
+  --task_groups "belebele-eu-cf" \
+  --venv_path .venv
+```
+
+If you need full manual control over all model args, set `LIGHTEVAL_MODEL_ARGS`,
+for example:
+
+```bash
+LIGHTEVAL_MODEL_ARGS='trust_remote_code=True,batch_size=4' oellm schedule-eval \
+  --models "model-name" --task_groups "belebele-eu-cf" --venv_path .venv
+```
 
 ## ⚠️ Dataset Pre-Download Warning
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The `HF_HUB_OFFLINE` value is read when you invoke `oellm` and baked into the ge
 
 ## SLURM Overrides
 
-Override cluster defaults (partition, account, time limit, memory, etc.) with `--slurm_template_var` (JSON object). By default, generated jobs request host RAM as `GPUS_PER_NODE * SLURM_MEM_PER_GPU_GB`, plus `LIGHTEVAL_EXTRA_MEM_GB` for lighteval runs. You can force an exact value with `SLURM_MEM`.
+Override cluster defaults (partition, account, time limit, memory, etc.) with `--slurm_template_var` (JSON object). Provide `SLURM_MEM` to request an exact host memory amount, otherwise falls back to a default of `96G`.
 
 ```bash
 # Use a different partition (e.g. dev-g on LUMI when small-g is crowded)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you need full manual control over all model args, set `MODEL_ARGS`,
 for example:
 
 ```bash
-MODEL_ARGS='batch_size=8, ...' oellm schedule-eval \
+MODEL_ARGS='batch_size=8' oellm schedule-eval \
   --models "model-name" --task_groups "belebele-eu-cf" --venv_path .venv
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Use exact env var names: `PARTITION`, `ACCOUNT`, `GPUS_PER_NODE`, `SLURM_MEM`. `
 
 ## Lighteval Batch Size
 
-For lighteval runs, generated jobs now default to `batch_size=1` for local runs and
+For lighteval runs, generated jobs default to `batch_size=1` for local runs and
 `batch_size=32` for non-local (SLURM/cluster) runs. This reduces the risk of
 out-of-memory failures where lighteval's auto batch-size detection can be
 overly optimistic for multiple-choice loglikelihood tasks. You can still
@@ -123,17 +123,17 @@ override these defaults:
 
 ```bash
 # Set an explicit batch size (overrides the local/cluster default)
-LIGHTEVAL_BATCH_SIZE=8 oellm schedule-eval \
+BATCH_SIZE=8 oellm schedule-eval \
   --models "model-name" \
   --task_groups "belebele-eu-cf" \
   --venv_path .venv
 ```
 
-If you need full manual control over all model args, set `LIGHTEVAL_MODEL_ARGS`,
+If you need full manual control over all model args, set `MODEL_ARGS`,
 for example:
 
 ```bash
-LIGHTEVAL_MODEL_ARGS='trust_remote_code=True,batch_size=4' oellm schedule-eval \
+MODEL_ARGS='batch_size=8, ...' oellm schedule-eval \
   --models "model-name" --task_groups "belebele-eu-cf" --venv_path .venv
 ```
 

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -745,7 +745,9 @@ def collect_results(
             # Prefer original extraction from `n_shot_data` and `global_n_shot`,
             # and fall back to parsing a '|N' suffix in the task name.
             task_name_clean, parsed_n = _split_task_and_nshot(task_name)
-            n_shot = n_shot_data.get(task_name_clean) or global_n_shot or parsed_n or "unknown"
+            n_shot = (
+                n_shot_data.get(task_name_clean) or global_n_shot or parsed_n or "unknown"
+            )
 
             # If this is a group aggregate and n_shot is missing, derive from any subtask
             if task_name_clean in group_aggregate_names and n_shot == "unknown":

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -14,6 +14,7 @@ import pandas as pd
 from jsonargparse import auto_cli
 
 from oellm.task_groups import (
+    _build_task_suite_map,
     _collect_dataset_specs,
     _expand_task_groups,
     _lookup_dataset_specs_for_tasks,
@@ -191,13 +192,14 @@ def schedule_evals(
 
     elif models:
         if task_groups is None:
+            task_suite_map = _build_task_suite_map()
             eval_jobs.extend(
                 [
                     EvaluationJob(
                         model_path=model,
                         task_path=task,
                         n_shot=shot,
-                        eval_suite="lm_eval",
+                        eval_suite=task_suite_map.get(task, "lm_eval"),
                     )
                     for model in models
                     for task in tasks

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -595,7 +595,7 @@ def collect_results(
             val, key = _first_matching_prefix(result_dict, preferred)
             return val, key
 
-        for metric in ["acc,none", "acc", "accuracy", "f1", "exact_match"]:
+        for metric in ["acc,none", "acc", "accuracy", "acc_norm", "f1", "exact_match"]:
             val, key = _first_numeric(result_dict, metric)
             if val is not None:
                 return val, key
@@ -604,14 +604,24 @@ def collect_results(
                 return val, key
         return None, None
 
+    def _split_task_and_nshot(name: str) -> tuple[str, int | None]:
+        """Split task names of the form 'task|N' returning (task, N) or (task, None)."""
+        if not isinstance(name, str):
+            return name, None
+        if "|" in name:
+            base, after = name.rsplit("|", 1)
+            if after.isdigit():
+                return base, int(after)
+        return name, None
+
     results_path = Path(results_dir)
     if not results_path.exists():
         raise ValueError(f"Results directory does not exist: {results_dir}")
 
     # Check if we need to look in a 'results' subdirectory
     if (results_path / "results").exists() and (results_path / "results").is_dir():
-        # User passed the top-level directory, look in results subdirectory
-        json_files = list((results_path / "results").glob("*.json"))
+        # User passed the top-level directory, look in results subdirectory for nested json files
+        json_files = list((results_path / "results").rglob("*.json"))
     else:
         # User passed the results directory directly
         json_files = list(results_path.glob("*.json"))
@@ -641,8 +651,17 @@ def collect_results(
         with open(json_file) as f:
             data = json.load(f)
 
-        # Extract model name/path
-        model_name = data.get("model_name", "unknown")
+        # Extract model name/path from a few common locations used in different
+        # versions of the result JSON schema.
+        model_name = (
+            data.get("model_name")
+            or data.get("config_general", {}).get("model_name")
+            or data.get("config_general", {}).get("model")
+            or data.get("config_general", {}).get("model_path")
+            or data.get("summary_general", {}).get("model")
+            or data.get("model")
+            or "unknown"
+        )
 
         # Extract results for each task
         results = data.get("results", {})
@@ -675,14 +694,21 @@ def collect_results(
         # Prefer only the first aggregate metric from groups (simplified)
         if groups_map:
             group_name, group_results = next(iter(groups_map.items()))
-            n_shot = n_shot_data.get(group_name, "unknown")
+            # Prefer original extraction from n_shot_data and subtasks, then
+            # global_n_shot; only fall back to parsing the group name.
+            orig_group_name = group_name
+            n_shot = n_shot_data.get(orig_group_name, "unknown")
             if n_shot == "unknown":
-                for subtask_name in group_subtasks_map.get(group_name, []):
+                for subtask_name in group_subtasks_map.get(orig_group_name, []):
                     if subtask_name in n_shot_data:
                         n_shot = n_shot_data[subtask_name]
                         break
             if n_shot == "unknown" and global_n_shot is not None:
                 n_shot = global_n_shot
+            # Fallback: parse possible '|N' suffix from group name
+            group_name, parsed_n = _split_task_and_nshot(orig_group_name)
+            if n_shot == "unknown" and parsed_n is not None:
+                n_shot = parsed_n
             performance, metric_name = _resolve_metric(group_name, group_results)
             if performance is not None:
                 if check:
@@ -715,12 +741,15 @@ def collect_results(
             if task_name.startswith("global_mmlu_") and task_name.count("_") >= 4:
                 continue
 
-            # Get n_shot for this task
-            n_shot = n_shot_data.get(task_name, "unknown")
+            # Get n_shot for this task.
+            # Prefer original extraction from `n_shot_data` and `global_n_shot`,
+            # and fall back to parsing a '|N' suffix in the task name.
+            task_name_clean, parsed_n = _split_task_and_nshot(task_name)
+            n_shot = n_shot_data.get(task_name_clean) or global_n_shot or parsed_n or "unknown"
 
             # If this is a group aggregate and n_shot is missing, derive from any subtask
-            if task_name in group_aggregate_names and n_shot == "unknown":
-                for subtask_name in group_subtasks_map.get(task_name, []):
+            if task_name_clean in group_aggregate_names and n_shot == "unknown":
+                for subtask_name in group_subtasks_map.get(task_name_clean, []):
                     if subtask_name in n_shot_data:
                         n_shot = n_shot_data[subtask_name]
                         break
@@ -728,7 +757,7 @@ def collect_results(
                 n_shot = global_n_shot
 
             # Special handling for MMLU aggregate - get n_shot from any MMLU subtask
-            if task_name == "mmlu" and n_shot == "unknown":
+            if task_name_clean == "mmlu" and n_shot == "unknown":
                 for key, value in n_shot_data.items():
                     if key.startswith("mmlu_"):
                         n_shot = value
@@ -737,8 +766,8 @@ def collect_results(
                     n_shot = global_n_shot
 
             # Special handling for Global MMLU aggregates - get n_shot from subtasks
-            if task_name.startswith("global_mmlu_") and n_shot == "unknown":
-                prefix = f"{task_name}_"
+            if task_name_clean.startswith("global_mmlu_") and n_shot == "unknown":
+                prefix = f"{task_name_clean}_"
                 for key, value in n_shot_data.items():
                     if key.startswith(prefix):
                         n_shot = value
@@ -752,12 +781,12 @@ def collect_results(
             if performance is not None:
                 # Track completed job for check mode
                 if check:
-                    completed_jobs.add((model_name, task_name, n_shot))
+                    completed_jobs.add((model_name, task_name_clean, n_shot))
 
                 rows.append(
                     {
                         "model_name": model_name,
-                        "task": task_name,
+                        "task": task_name_clean,
                         "n_shot": n_shot,
                         "performance": performance,
                         "metric_name": metric_name if metric_name is not None else "",

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -48,6 +48,75 @@ def _resolve_hf_hub_offline(local: bool) -> int:
     return 0 if local else 1
 
 
+def _read_positive_int_env(key: str, default: int) -> int:
+    raw = os.environ.get(key)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(str(raw).strip())
+    except ValueError:
+        logging.warning("Invalid %s=%r; using %s", key, raw, default)
+        return default
+    if value < 1:
+        logging.warning("%s must be >= 1 (got %r); using %s", key, raw, default)
+        return default
+    return value
+
+
+def _resolve_slurm_mem(eval_suites: list[str]) -> str:
+    """Return the host-memory request for the generated SLURM job."""
+    explicit_mem = os.environ.get("SLURM_MEM")
+    if explicit_mem is not None and str(explicit_mem).strip() != "":
+        return str(explicit_mem).strip()
+
+    gpus_per_node = _read_positive_int_env("GPUS_PER_NODE", 1)
+    mem_per_gpu_gb = _read_positive_int_env("SLURM_MEM_PER_GPU_GB", 48)
+    min_mem_gb = _read_positive_int_env("SLURM_MIN_MEM_GB", mem_per_gpu_gb)
+
+    normalized_suites = {suite.strip().lower() for suite in eval_suites}
+    extra_mem_gb = 0
+    if {"lighteval", "light-eval"} & normalized_suites:
+        # Lighteval eagerly loads a large task registry and benefits from extra host RAM.
+        extra_mem_gb = _read_positive_int_env("LIGHTEVAL_EXTRA_MEM_GB", 16)
+
+    mem_gb = max(min_mem_gb, gpus_per_node * mem_per_gpu_gb + extra_mem_gb)
+    return f"{mem_gb}G"
+
+
+def _resolve_lighteval_model_args(local: bool = False) -> str:
+    """Return model args for lighteval, defaulting to an explicit batch size.
+
+    Defaults:
+    - if `local` is True: `batch_size=1`
+    - otherwise: `batch_size=32`
+
+    Users may override the entire model args via `LIGHTEVAL_MODEL_ARGS` or the
+    batch size via `LIGHTEVAL_BATCH_SIZE` environment variables.
+    """
+    explicit_model_args = os.environ.get("LIGHTEVAL_MODEL_ARGS")
+    if explicit_model_args is not None and str(explicit_model_args).strip() != "":
+        return str(explicit_model_args).strip()
+
+    batch_size = os.environ.get("LIGHTEVAL_BATCH_SIZE")
+    if batch_size is not None and str(batch_size).strip() != "":
+        batch_size_value = str(batch_size).strip()
+        try:
+            if int(batch_size_value) < 1:
+                raise ValueError
+        except ValueError:
+            fallback = "1" if local else "32"
+            logging.warning(
+                "Invalid LIGHTEVAL_BATCH_SIZE=%r; falling back to batch_size=%s",
+                batch_size,
+                fallback,
+            )
+            batch_size_value = fallback
+    else:
+        batch_size_value = "1" if local else "32"
+
+    return f"trust_remote_code=True,batch_size={batch_size_value}"
+
+
 @dataclass
 class EvaluationJob:
     model_path: Path | str
@@ -114,8 +183,8 @@ def schedule_evals(
             submitting to SLURM. Requires --venv_path. Skips cluster environment detection and
             runs all evaluations sequentially in a single process.
         slurm_template_var: JSON object of template variable overrides. Use exact env var names
-            (PARTITION, ACCOUNT, GPUS_PER_NODE). "TIME" overrides the time limit.
-            Example: '{"PARTITION":"dev-g","ACCOUNT":"FOO","TIME":"02:00:00","GPUS_PER_NODE":2}'
+            (PARTITION, ACCOUNT, GPUS_PER_NODE, SLURM_MEM). "TIME" overrides the time limit.
+            Example: '{"PARTITION":"dev-g","ACCOUNT":"FOO","TIME":"02:00:00","GPUS_PER_NODE":2,"SLURM_MEM":"96G"}'
     """
     _setup_logging(verbose)
 
@@ -358,6 +427,7 @@ def schedule_evals(
                 logging.info(f"Using slurm_template_var override: {key}={value}")
 
     # Log the calculated values
+    slurm_mem = _resolve_slurm_mem(df["eval_suite"].unique().tolist())
     logging.info("📊 Evaluation planning:")
     logging.info(f"   Total evaluations: {total_evals}")
     logging.info(f"   Estimated time per eval: {minutes_per_eval} minutes")
@@ -373,6 +443,7 @@ def schedule_evals(
         f"   Time per job: {minutes_per_job} minutes ({minutes_per_job / 60:.1f} hours)"
     )
     logging.info(f"   Time limit with safety margin: {time_limit}")
+    logging.info(f"   Requested host memory: {slurm_mem}")
 
     sbatch_script = sbatch_template.format(
         csv_path=csv_path,
@@ -383,14 +454,13 @@ def schedule_evals(
         log_dir=evals_dir / "slurm_logs",
         evals_dir=str(evals_dir / "results"),
         time_limit=time_limit,  # Dynamic time limit
+        slurm_mem=slurm_mem,
         limit=limit if limit else "",  # Sample limit for quick testing
         venv_path=venv_path or "",
         lm_eval_include_path=lm_eval_include_path
         or str(files("oellm.resources") / "custom_lm_eval_tasks"),
         hf_hub_offline=_resolve_hf_hub_offline(local),
-        lighteval_model_args="trust_remote_code=True,batch_size=1"
-        if local
-        else "trust_remote_code=True",
+        lighteval_model_args=_resolve_lighteval_model_args(local),  # Batch size
         evalchemy_dir=os.environ.get("EVALCHEMY_DIR", "/opt/evalchemy"),
     )
 

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -60,21 +60,21 @@ def _resolve_slurm_mem() -> str:
     return "96G"
 
 
-def _resolve_lighteval_model_args(local: bool = False) -> str:
+def _resolve_additional_model_args(local: bool = False) -> str:
     """Return model args for lighteval, defaulting to an explicit batch size.
-
-    Defaults:
     - if `local` is True: `batch_size=1`
     - otherwise: `batch_size=32`
 
-    Users may override the entire model args via `LIGHTEVAL_MODEL_ARGS` or the
-    batch size via `LIGHTEVAL_BATCH_SIZE` environment variables.
+    Users may override the entire model args via `MODEL_ARGS` or the
+    batch size via `BATCH_SIZE` environment variables.
+
+    For now this is only passed to suite lighteval, not to evalchemy and lm-eval yet.
     """
-    explicit_model_args = os.environ.get("LIGHTEVAL_MODEL_ARGS")
+    explicit_model_args = os.environ.get("MODEL_ARGS")
     if explicit_model_args is not None and str(explicit_model_args).strip() != "":
         return str(explicit_model_args).strip()
 
-    batch_size = os.environ.get("LIGHTEVAL_BATCH_SIZE")
+    batch_size = os.environ.get("BATCH_SIZE")
     if batch_size is not None and str(batch_size).strip() != "":
         batch_size_value = str(batch_size).strip()
         try:
@@ -83,7 +83,7 @@ def _resolve_lighteval_model_args(local: bool = False) -> str:
         except ValueError:
             fallback = "1" if local else "32"
             logging.warning(
-                "Invalid LIGHTEVAL_BATCH_SIZE=%r; falling back to batch_size=%s",
+                "Invalid BATCH_SIZE=%r; falling back to batch_size=%s",
                 batch_size,
                 fallback,
             )
@@ -91,7 +91,7 @@ def _resolve_lighteval_model_args(local: bool = False) -> str:
     else:
         batch_size_value = "1" if local else "32"
 
-    return f"trust_remote_code=True,batch_size={batch_size_value}"
+    return f"batch_size={batch_size_value}"
 
 
 @dataclass
@@ -437,7 +437,7 @@ def schedule_evals(
         lm_eval_include_path=lm_eval_include_path
         or str(files("oellm.resources") / "custom_lm_eval_tasks"),
         hf_hub_offline=_resolve_hf_hub_offline(local),
-        lighteval_model_args=_resolve_lighteval_model_args(local),  # Batch size
+        additional_model_args=_resolve_additional_model_args(local),  # Batch size
         evalchemy_dir=os.environ.get("EVALCHEMY_DIR", "/opt/evalchemy"),
     )
 

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -48,39 +48,16 @@ def _resolve_hf_hub_offline(local: bool) -> int:
     return 0 if local else 1
 
 
-def _read_positive_int_env(key: str, default: int) -> int:
-    raw = os.environ.get(key)
-    if raw is None or str(raw).strip() == "":
-        return default
-    try:
-        value = int(str(raw).strip())
-    except ValueError:
-        logging.warning("Invalid %s=%r; using %s", key, raw, default)
-        return default
-    if value < 1:
-        logging.warning("%s must be >= 1 (got %r); using %s", key, raw, default)
-        return default
-    return value
-
-
-def _resolve_slurm_mem(eval_suites: list[str]) -> str:
+def _resolve_slurm_mem() -> str:
     """Return the host-memory request for the generated SLURM job."""
     explicit_mem = os.environ.get("SLURM_MEM")
     if explicit_mem is not None and str(explicit_mem).strip() != "":
         return str(explicit_mem).strip()
 
-    gpus_per_node = _read_positive_int_env("GPUS_PER_NODE", 1)
-    mem_per_gpu_gb = _read_positive_int_env("SLURM_MEM_PER_GPU_GB", 48)
-    min_mem_gb = _read_positive_int_env("SLURM_MIN_MEM_GB", mem_per_gpu_gb)
-
-    normalized_suites = {suite.strip().lower() for suite in eval_suites}
-    extra_mem_gb = 0
-    if {"lighteval", "light-eval"} & normalized_suites:
-        # Lighteval eagerly loads a large task registry and benefits from extra host RAM.
-        extra_mem_gb = _read_positive_int_env("LIGHTEVAL_EXTRA_MEM_GB", 16)
-
-    mem_gb = max(min_mem_gb, gpus_per_node * mem_per_gpu_gb + extra_mem_gb)
-    return f"{mem_gb}G"
+    logging.warning(
+        "SLURM_MEM not set; falling back to default memory request '96G'."
+    )
+    return "96G"
 
 
 def _resolve_lighteval_model_args(local: bool = False) -> str:
@@ -427,7 +404,7 @@ def schedule_evals(
                 logging.info(f"Using slurm_template_var override: {key}={value}")
 
     # Log the calculated values
-    slurm_mem = _resolve_slurm_mem(df["eval_suite"].unique().tolist())
+    slurm_mem = _resolve_slurm_mem()
     logging.info("📊 Evaluation planning:")
     logging.info(f"   Total evaluations: {total_evals}")
     logging.info(f"   Estimated time per eval: {minutes_per_eval} minutes")

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -54,9 +54,7 @@ def _resolve_slurm_mem() -> str:
     if explicit_mem is not None and str(explicit_mem).strip() != "":
         return str(explicit_mem).strip()
 
-    logging.warning(
-        "SLURM_MEM not set; falling back to default memory request '96G'."
-    )
+    logging.warning("SLURM_MEM not set; falling back to default memory request '96G'.")
     return "96G"
 
 

--- a/oellm/resources/clusters.yaml
+++ b/oellm/resources/clusters.yaml
@@ -3,6 +3,9 @@ shared:
   UV_LINK_MODE: "copy"
   EVAL_OUTPUT_DIR: "{EVAL_BASE_DIR}/{USER}"  # where evaluations are written
   GPUS_PER_NODE: 1
+  SLURM_MEM_PER_GPU_GB: 48  # default host RAM requested per GPU
+  SLURM_MIN_MEM_GB: 48  # floor for single-GPU jobs
+  LIGHTEVAL_EXTRA_MEM_GB: 16  # extra RAM for large lighteval task registries
   HF_HUB_DISABLE_PROGRESS_BARS: "1"
   HF_DATASETS_DISABLE_PROGRESS_BARS: "1"
 

--- a/oellm/resources/clusters.yaml
+++ b/oellm/resources/clusters.yaml
@@ -3,9 +3,6 @@ shared:
   UV_LINK_MODE: "copy"
   EVAL_OUTPUT_DIR: "{EVAL_BASE_DIR}/{USER}"  # where evaluations are written
   GPUS_PER_NODE: 1
-  SLURM_MEM_PER_GPU_GB: 48  # default host RAM requested per GPU
-  SLURM_MIN_MEM_GB: 48  # floor for single-GPU jobs
-  LIGHTEVAL_EXTRA_MEM_GB: 16  # extra RAM for large lighteval task registries
   HF_HUB_DISABLE_PROGRESS_BARS: "1"
   HF_DATASETS_DISABLE_PROGRESS_BARS: "1"
 

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -1,5 +1,29 @@
 task_metrics:
   mmlu: acc
+  belebele_bul_Cyrl_cf: acc
+  belebele_hrv_Latn_cf: acc
+  belebele_ces_Latn_cf: acc
+  belebele_dan_Latn_cf: acc
+  belebele_nld_Latn_cf: acc
+  belebele_eng_Latn_cf: acc
+  belebele_est_Latn_cf: acc
+  belebele_fin_Latn_cf: acc
+  belebele_fra_Latn_cf: acc
+  belebele_deu_Latn_cf: acc
+  belebele_ell_Grek_cf: acc
+  belebele_hun_Latn_cf: acc
+  belebele_ita_Latn_cf: acc
+  belebele_lvs_Latn_cf: acc
+  belebele_lit_Latn_cf: acc
+  belebele_mlt_Latn_cf: acc
+  belebele_pol_Latn_cf: acc
+  belebele_por_Latn_cf: acc
+  belebele_ron_Latn_cf: acc
+  belebele_slk_Latn_cf: acc
+  belebele_slv_Latn_cf: acc
+  belebele_spa_Latn_cf: acc
+  belebele_swe_Latn_cf: acc
+  belebele_nob_Latn_cf: acc
   copa: acc
   lambada_openai: acc
   openbookqa: acc_norm
@@ -121,6 +145,60 @@ task_groups:
       - task: belebele_swe_Latn
         subset: swe_Latn
       - task: belebele_nob_Latn
+        subset: nob_Latn
+  belebele-eu-cf:
+    description: "Belebele European language tasks (cloze formulation, lighteval)"
+    suite: lighteval
+    n_shots: [0]
+    dataset: facebook/belebele
+    tasks:
+      - task: belebele_bul_Cyrl_cf
+        subset: bul_Cyrl
+      - task: belebele_hrv_Latn_cf
+        subset: hrv_Latn
+      - task: belebele_ces_Latn_cf
+        subset: ces_Latn
+      - task: belebele_dan_Latn_cf
+        subset: dan_Latn
+      - task: belebele_nld_Latn_cf
+        subset: nld_Latn
+      - task: belebele_eng_Latn_cf
+        subset: eng_Latn
+      - task: belebele_est_Latn_cf
+        subset: est_Latn
+      - task: belebele_fin_Latn_cf
+        subset: fin_Latn
+      - task: belebele_fra_Latn_cf
+        subset: fra_Latn
+      - task: belebele_deu_Latn_cf
+        subset: deu_Latn
+      - task: belebele_ell_Grek_cf
+        subset: ell_Grek
+      - task: belebele_hun_Latn_cf
+        subset: hun_Latn
+      - task: belebele_ita_Latn_cf
+        subset: ita_Latn
+      - task: belebele_lvs_Latn_cf
+        subset: lvs_Latn
+      - task: belebele_lit_Latn_cf
+        subset: lit_Latn
+      - task: belebele_mlt_Latn_cf
+        subset: mlt_Latn
+      - task: belebele_pol_Latn_cf
+        subset: pol_Latn
+      - task: belebele_por_Latn_cf
+        subset: por_Latn
+      - task: belebele_ron_Latn_cf
+        subset: ron_Latn
+      - task: belebele_slk_Latn_cf
+        subset: slk_Latn
+      - task: belebele_slv_Latn_cf
+        subset: slv_Latn
+      - task: belebele_spa_Latn_cf
+        subset: spa_Latn
+      - task: belebele_swe_Latn_cf
+        subset: swe_Latn
+      - task: belebele_nob_Latn_cf
         subset: nob_Latn
   flores-200-eu-to-eng:
     description: "Flores 200 EU to English translation"

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -1,29 +1,31 @@
 task_metrics:
   mmlu: acc
-  belebele_bul_Cyrl_cf: acc
-  belebele_hrv_Latn_cf: acc
-  belebele_ces_Latn_cf: acc
-  belebele_dan_Latn_cf: acc
-  belebele_nld_Latn_cf: acc
-  belebele_eng_Latn_cf: acc
-  belebele_est_Latn_cf: acc
-  belebele_fin_Latn_cf: acc
-  belebele_fra_Latn_cf: acc
-  belebele_deu_Latn_cf: acc
-  belebele_ell_Grek_cf: acc
-  belebele_hun_Latn_cf: acc
-  belebele_ita_Latn_cf: acc
-  belebele_lvs_Latn_cf: acc
-  belebele_lit_Latn_cf: acc
-  belebele_mlt_Latn_cf: acc
-  belebele_pol_Latn_cf: acc
-  belebele_por_Latn_cf: acc
-  belebele_ron_Latn_cf: acc
-  belebele_slk_Latn_cf: acc
-  belebele_slv_Latn_cf: acc
-  belebele_spa_Latn_cf: acc
-  belebele_swe_Latn_cf: acc
-  belebele_nob_Latn_cf: acc
+  belebele_bul_Cyrl_cf: acc_norm
+  belebele_hrv_Latn_cf: acc_norm
+  belebele_ces_Latn_cf: acc_norm
+  belebele_dan_Latn_cf: acc_norm
+  belebele_nld_Latn_cf: acc_norm
+  belebele_eng_Latn_cf: acc_norm
+  belebele_est_Latn_cf: acc_norm
+  belebele_fin_Latn_cf: acc_norm
+  belebele_fra_Latn_cf: acc_norm
+  belebele_deu_Latn_cf: acc_norm
+  belebele_ell_Grek_cf: acc_norm
+  belebele_hun_Latn_cf: acc_norm
+  belebele_ita_Latn_cf: acc_norm
+  belebele_lvs_Latn_cf: acc_norm
+  belebele_lit_Latn_cf: acc_norm
+  belebele_mlt_Latn_cf: acc_norm
+  belebele_pol_Latn_cf: acc_norm
+  belebele_por_Latn_cf: acc_norm
+  belebele_ron_Latn_cf: acc_norm
+  belebele_slk_Latn_cf: acc_norm
+  belebele_slv_Latn_cf: acc_norm
+  belebele_spa_Latn_cf: acc_norm
+  belebele_swe_Latn_cf: acc_norm
+  belebele_nob_Latn_cf: acc_norm
+  belebele_eus_Latn_cf: acc_norm
+  belebele_cat_Latn_cf: acc_norm
   copa: acc
   lambada_openai: acc
   openbookqa: acc_norm
@@ -200,6 +202,11 @@ task_groups:
         subset: swe_Latn
       - task: belebele_nob_Latn_cf
         subset: nob_Latn
+      - task: belebele_eus_Latn_cf
+        subset: eus_Latn
+      - task: belebele_cat_Latn_cf
+        subset: cat_Latn
+      
   flores-200-eu-to-eng:
     description: "Flores 200 EU to English translation"
     suite: lighteval

--- a/oellm/resources/template.sbatch
+++ b/oellm/resources/template.sbatch
@@ -2,6 +2,7 @@
 #SBATCH --job-name=oellm-eval
 #SBATCH --time={time_limit}
 #SBATCH --gres=gpu:$GPUS_PER_NODE
+#SBATCH --mem={slurm_mem}
 #SBATCH --output={log_dir}/%x-%A-%a.out
 #SBATCH --partition=$PARTITION
 #SBATCH --account=$ACCOUNT
@@ -127,6 +128,66 @@ do
         fi
     }}
 
+    print_gpu_runtime_info() {{
+        echo "[debug] CUDA_VISIBLE_DEVICES: $GPU_DEVICES"
+        echo "[debug] SLURM_JOB_GPUS: ${{SLURM_JOB_GPUS:-<unset>}}"
+
+        if [ -n "$VENV_PATH" ]; then
+            nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
+        else
+            singularity exec $SINGULARITY_ARGS \
+                $SINGULARITY_ENV_ARGS \
+                $SINGULARITY_HOME_ARG \
+                --bind $BIND_PATHS \
+                $EVAL_SIF_PATH \
+                env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
+                nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
+        fi
+
+        run_python -c 'import torch; print(f"[debug] torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}"); [print(f"[debug] torch gpu[{{idx}}] name={{torch.cuda.get_device_properties(idx).name}} total_memory_gib={{torch.cuda.get_device_properties(idx).total_memory / (1024 ** 3):.2f}}") for idx in range(torch.cuda.device_count())]' || true
+    }}
+
+    print_lighteval_runtime_info() {{
+        if [ -n "$VENV_PATH" ]; then
+            source "$VENV_PATH/bin/activate"
+            LIGHTEVAL_BIN=$(command -v lighteval || true)
+            echo "[debug] lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
+
+            if [ -n "$LIGHTEVAL_BIN" ]; then
+                LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf '%s\n' "$LIGHTEVAL_BIN")
+                echo "[debug] lighteval resolved path: $LIGHTEVAL_REAL"
+                LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n 's/^#!//p')
+                echo "[debug] lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
+
+                if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
+                    "$LIGHTEVAL_PY" -c 'import torch; print(f"[debug] torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")' || true
+                fi
+            fi
+        else
+            singularity exec $SINGULARITY_ARGS \
+                $SINGULARITY_ENV_ARGS \
+                $SINGULARITY_HOME_ARG \
+                --bind $BIND_PATHS \
+                $EVAL_SIF_PATH \
+                env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
+                bash -lc '
+                    LIGHTEVAL_BIN=$(command -v lighteval || true)
+                    echo "[debug] lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
+
+                    if [ -n "$LIGHTEVAL_BIN" ]; then
+                        LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf "%s\n" "$LIGHTEVAL_BIN")
+                        echo "[debug] lighteval resolved path: $LIGHTEVAL_REAL"
+                        LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n "s/^#!//p")
+                        echo "[debug] lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
+
+                        if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
+                            "$LIGHTEVAL_PY" -c '"'"'import torch; print(f"[debug] torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")'"'"' || true
+                        fi
+                    fi
+                '
+        fi
+    }}
+
     case "$suite_normalized" in
         lm_eval|lm-eval|lm-eval-harness)
             run_python -m lm_eval --model hf \
@@ -158,6 +219,9 @@ do
 
             RESULTS_SUBDIR="{evals_dir}/$(openssl rand -hex 5)"
             mkdir -p "$RESULTS_SUBDIR"
+            echo "[debug] lighteval model args: {lighteval_model_args}"
+            print_gpu_runtime_info
+            print_lighteval_runtime_info
 
             if [ -n "$VENV_PATH" ]; then
                 source "$VENV_PATH/bin/activate"

--- a/oellm/resources/template.sbatch
+++ b/oellm/resources/template.sbatch
@@ -129,12 +129,14 @@ do
     }}
 
     print_gpu_runtime_info() {{
-        echo "[debug] CUDA_VISIBLE_DEVICES: $GPU_DEVICES"
-        echo "[debug] SLURM_JOB_GPUS: ${{SLURM_JOB_GPUS:-<unset>}}"
+        echo "CUDA_VISIBLE_DEVICES: $GPU_DEVICES"
+        echo "SLURM_JOB_GPUS: ${{SLURM_JOB_GPUS:-<unset>}}"
 
         if [ -n "$VENV_PATH" ]; then
+            echo "nvidia-smi output:"
             nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
         else
+            echo "nvidia-smi output (container):"
             singularity exec $SINGULARITY_ARGS \
                 $SINGULARITY_ENV_ARGS \
                 $SINGULARITY_HOME_ARG \
@@ -144,23 +146,24 @@ do
                 nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
         fi
 
-        run_python -c 'import torch; print(f"[debug] torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}"); [print(f"[debug] torch gpu[{{idx}}] name={{torch.cuda.get_device_properties(idx).name}} total_memory_gib={{torch.cuda.get_device_properties(idx).total_memory / (1024 ** 3):.2f}}") for idx in range(torch.cuda.device_count())]' || true
+        run_python -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}"); [print(f"torch gpu[{{idx}}] name={{torch.cuda.get_device_properties(idx).name}} total_memory_gib={{torch.cuda.get_device_properties(idx).total_memory / (1024 ** 3):.2f}}") for idx in range(torch.cuda.device_count())]' || true
     }}
 
     print_lighteval_runtime_info() {{
+        echo "=== lighteval ==="
         if [ -n "$VENV_PATH" ]; then
             source "$VENV_PATH/bin/activate"
             LIGHTEVAL_BIN=$(command -v lighteval || true)
-            echo "[debug] lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
+            echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
 
             if [ -n "$LIGHTEVAL_BIN" ]; then
                 LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf '%s\n' "$LIGHTEVAL_BIN")
-                echo "[debug] lighteval resolved path: $LIGHTEVAL_REAL"
+                echo "lighteval resolved path: $LIGHTEVAL_REAL"
                 LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n 's/^#!//p')
-                echo "[debug] lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
+                echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
 
                 if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
-                    "$LIGHTEVAL_PY" -c 'import torch; print(f"[debug] torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")' || true
+                    "$LIGHTEVAL_PY" -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")' || true
                 fi
             fi
         else
@@ -172,16 +175,16 @@ do
                 env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
                 bash -lc '
                     LIGHTEVAL_BIN=$(command -v lighteval || true)
-                    echo "[debug] lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
+                    echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
 
                     if [ -n "$LIGHTEVAL_BIN" ]; then
                         LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf "%s\n" "$LIGHTEVAL_BIN")
-                        echo "[debug] lighteval resolved path: $LIGHTEVAL_REAL"
+                        echo "lighteval resolved path: $LIGHTEVAL_REAL"
                         LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n "s/^#!//p")
-                        echo "[debug] lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
+                        echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
 
                         if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
-                            "$LIGHTEVAL_PY" -c '"'"'import torch; print(f"[debug] torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")'"'"' || true
+                            "$LIGHTEVAL_PY" -c '"'"'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")'"'"' || true
                         fi
                     fi
                 '
@@ -219,7 +222,7 @@ do
 
             RESULTS_SUBDIR="{evals_dir}/$(openssl rand -hex 5)"
             mkdir -p "$RESULTS_SUBDIR"
-            echo "[debug] lighteval model args: {lighteval_model_args}"
+            echo "lighteval model args: {lighteval_model_args}"
             print_gpu_runtime_info
             print_lighteval_runtime_info
 

--- a/oellm/resources/template.sbatch
+++ b/oellm/resources/template.sbatch
@@ -128,71 +128,34 @@ do
         fi
     }}
 
-    print_gpu_runtime_info() {{
-        echo "CUDA_VISIBLE_DEVICES: $GPU_DEVICES"
-        echo "SLURM_JOB_GPUS: ${{SLURM_JOB_GPUS:-<unset>}}"
+    echo
+    echo "-----------------------------------------------"
+    echo "GPU Runtime Info:"
+    echo "CUDA_VISIBLE_DEVICES: $GPU_DEVICES"
+    echo "SLURM_JOB_GPUS: ${{SLURM_JOB_GPUS:-<unset>}}"
 
-        if [ -n "$VENV_PATH" ]; then
-            echo "nvidia-smi output:"
+    if [ -n "$VENV_PATH" ]; then
+        echo "nvidia-smi output:"
+        nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
+    else
+        echo "nvidia-smi output (container):"
+        singularity exec $SINGULARITY_ARGS \
+            $SINGULARITY_ENV_ARGS \
+            $SINGULARITY_HOME_ARG \
+            --bind $BIND_PATHS \
+            $EVAL_SIF_PATH \
+            env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
             nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
-        else
-            echo "nvidia-smi output (container):"
-            singularity exec $SINGULARITY_ARGS \
-                $SINGULARITY_ENV_ARGS \
-                $SINGULARITY_HOME_ARG \
-                --bind $BIND_PATHS \
-                $EVAL_SIF_PATH \
-                env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
-                nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
-        fi
+    fi
 
-        run_python -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}"); [print(f"torch gpu[{{idx}}] name={{torch.cuda.get_device_properties(idx).name}} total_memory_gib={{torch.cuda.get_device_properties(idx).total_memory / (1024 ** 3):.2f}}") for idx in range(torch.cuda.device_count())]' || true
-    }}
-
-    print_lighteval_runtime_info() {{
-        echo "=== lighteval ==="
-        if [ -n "$VENV_PATH" ]; then
-            source "$VENV_PATH/bin/activate"
-            LIGHTEVAL_BIN=$(command -v lighteval || true)
-            echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
-
-            if [ -n "$LIGHTEVAL_BIN" ]; then
-                LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf '%s\n' "$LIGHTEVAL_BIN")
-                echo "lighteval resolved path: $LIGHTEVAL_REAL"
-                LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n 's/^#!//p')
-                echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
-
-                if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
-                    "$LIGHTEVAL_PY" -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")' || true
-                fi
-            fi
-        else
-            singularity exec $SINGULARITY_ARGS \
-                $SINGULARITY_ENV_ARGS \
-                $SINGULARITY_HOME_ARG \
-                --bind $BIND_PATHS \
-                $EVAL_SIF_PATH \
-                env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
-                bash -lc '
-                    LIGHTEVAL_BIN=$(command -v lighteval || true)
-                    echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
-
-                    if [ -n "$LIGHTEVAL_BIN" ]; then
-                        LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf "%s\n" "$LIGHTEVAL_BIN")
-                        echo "lighteval resolved path: $LIGHTEVAL_REAL"
-                        LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n "s/^#!//p")
-                        echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
-
-                        if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
-                            "$LIGHTEVAL_PY" -c '"'"'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")'"'"' || true
-                        fi
-                    fi
-                '
-        fi
-    }}
+    run_python -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}"); [print(f"torch gpu[{{idx}}] name={{torch.cuda.get_device_properties(idx).name}} total_memory_gib={{torch.cuda.get_device_properties(idx).total_memory / (1024 ** 3):.2f}}") for idx in range(torch.cuda.device_count())]' || true
+    echo "-----------------------------------------------"
 
     case "$suite_normalized" in
         lm_eval|lm-eval|lm-eval-harness)
+            echo
+            echo "----------------------------------------------------"
+            echo "lm_eval Execution"
             run_python -m lm_eval --model hf \
                 --model_args pretrained="$model_path",trust_remote_code=True \
                 --tasks "$task_path" \
@@ -201,6 +164,7 @@ do
                 --trust_remote_code \
                 ${{LM_EVAL_INCLUDE_PATH:+--include_path $LM_EVAL_INCLUDE_PATH}} \
                 ${{LIMIT:+--limit $LIMIT}}
+            echo "----------------------------------------------------"
             ;;
         lighteval|light-eval)
             LIGHT_TASK="$task_path"
@@ -222,14 +186,56 @@ do
 
             RESULTS_SUBDIR="{evals_dir}/$(openssl rand -hex 5)"
             mkdir -p "$RESULTS_SUBDIR"
-            echo "lighteval model args: {lighteval_model_args}"
-            print_gpu_runtime_info
-            print_lighteval_runtime_info
+
+            echo
+            echo "----------------------------------------------------"
+            echo "Lighteval Runtime Info:"
+            if [ -n "$VENV_PATH" ]; then
+                source "$VENV_PATH/bin/activate"
+                LIGHTEVAL_BIN=$(command -v lighteval || true)
+                echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
+
+                if [ -n "$LIGHTEVAL_BIN" ]; then
+                    LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf '%s\n' "$LIGHTEVAL_BIN")
+                    echo "lighteval resolved path: $LIGHTEVAL_REAL"
+                    LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n 's/^#!//p')
+                    echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
+
+                    echo "lighteval cuda: ${{LIGHTEVAL_BIN:-<not found>}}"
+                    if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
+                        "$LIGHTEVAL_PY" -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")' || true
+                    fi
+                fi
+            else
+                singularity exec $SINGULARITY_ARGS \
+                    $SINGULARITY_ENV_ARGS \
+                    $SINGULARITY_HOME_ARG \
+                    --bind $BIND_PATHS \
+                    $EVAL_SIF_PATH \
+                    env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
+                    bash -lc '
+                        LIGHTEVAL_BIN=$(command -v lighteval || true)
+                        echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
+
+                        if [ -n "$LIGHTEVAL_BIN" ]; then
+                            LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf "%s\n" "$LIGHTEVAL_BIN")
+                            echo "lighteval resolved path: $LIGHTEVAL_REAL"
+                            LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n "s/^#!//p")
+                            echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
+
+                            if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
+                                "$LIGHTEVAL_PY" -c '"'"'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")'"'"' || true
+                            fi
+                        fi
+                    '
+            fi
+            echo "----------------------------------------------------"
+            echo
 
             if [ -n "$VENV_PATH" ]; then
                 source "$VENV_PATH/bin/activate"
                 lighteval accelerate \
-                    "model_name=$model_path,{lighteval_model_args}" \
+                    "model_name=$model_path,trust_remote_code=True,{additional_model_args}" \
                     "$LIGHT_TASK_ARG" \
                     --load-tasks-multilingual \
                     --output-dir "$RESULTS_SUBDIR" \
@@ -242,7 +248,7 @@ do
                     $EVAL_SIF_PATH \
                     env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
                     lighteval accelerate \
-                        "model_name=$model_path,{lighteval_model_args}" \
+                        "model_name=$model_path,{additional_model_args}" \
                         "$LIGHT_TASK_ARG" \
                         --load-tasks-multilingual \
                         --output-dir "$RESULTS_SUBDIR" \
@@ -273,6 +279,7 @@ do
             ;;
     esac
 
+    echo "----------------------------------------------------"
     echo "Evaluation finished for model: $model_path"
 
 done

--- a/oellm/resources/template.sbatch
+++ b/oellm/resources/template.sbatch
@@ -128,29 +128,6 @@ do
         fi
     }}
 
-    echo
-    echo "-----------------------------------------------"
-    echo "GPU Runtime Info:"
-    echo "CUDA_VISIBLE_DEVICES: $GPU_DEVICES"
-    echo "SLURM_JOB_GPUS: ${{SLURM_JOB_GPUS:-<unset>}}"
-
-    if [ -n "$VENV_PATH" ]; then
-        echo "nvidia-smi output:"
-        nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
-    else
-        echo "nvidia-smi output (container):"
-        singularity exec $SINGULARITY_ARGS \
-            $SINGULARITY_ENV_ARGS \
-            $SINGULARITY_HOME_ARG \
-            --bind $BIND_PATHS \
-            $EVAL_SIF_PATH \
-            env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
-            nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free --format=csv,noheader || true
-    fi
-
-    run_python -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}"); [print(f"torch gpu[{{idx}}] name={{torch.cuda.get_device_properties(idx).name}} total_memory_gib={{torch.cuda.get_device_properties(idx).total_memory / (1024 ** 3):.2f}}") for idx in range(torch.cuda.device_count())]' || true
-    echo "-----------------------------------------------"
-
     case "$suite_normalized" in
         lm_eval|lm-eval|lm-eval-harness)
             echo
@@ -186,51 +163,6 @@ do
 
             RESULTS_SUBDIR="{evals_dir}/$(openssl rand -hex 5)"
             mkdir -p "$RESULTS_SUBDIR"
-
-            echo
-            echo "----------------------------------------------------"
-            echo "Lighteval Runtime Info:"
-            if [ -n "$VENV_PATH" ]; then
-                source "$VENV_PATH/bin/activate"
-                LIGHTEVAL_BIN=$(command -v lighteval || true)
-                echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
-
-                if [ -n "$LIGHTEVAL_BIN" ]; then
-                    LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf '%s\n' "$LIGHTEVAL_BIN")
-                    echo "lighteval resolved path: $LIGHTEVAL_REAL"
-                    LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n 's/^#!//p')
-                    echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
-
-                    echo "lighteval cuda: ${{LIGHTEVAL_BIN:-<not found>}}"
-                    if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
-                        "$LIGHTEVAL_PY" -c 'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")' || true
-                    fi
-                fi
-            else
-                singularity exec $SINGULARITY_ARGS \
-                    $SINGULARITY_ENV_ARGS \
-                    $SINGULARITY_HOME_ARG \
-                    --bind $BIND_PATHS \
-                    $EVAL_SIF_PATH \
-                    env CUDA_VISIBLE_DEVICES=$GPU_DEVICES \
-                    bash -lc '
-                        LIGHTEVAL_BIN=$(command -v lighteval || true)
-                        echo "lighteval path: ${{LIGHTEVAL_BIN:-<not found>}}"
-
-                        if [ -n "$LIGHTEVAL_BIN" ]; then
-                            LIGHTEVAL_REAL=$(readlink -f "$LIGHTEVAL_BIN" 2>/dev/null || printf "%s\n" "$LIGHTEVAL_BIN")
-                            echo "lighteval resolved path: $LIGHTEVAL_REAL"
-                            LIGHTEVAL_PY=$(head -n 1 "$LIGHTEVAL_REAL" 2>/dev/null | sed -n "s/^#!//p")
-                            echo "lighteval python: ${{LIGHTEVAL_PY:-<unknown>}}"
-
-                            if [ -n "$LIGHTEVAL_PY" ] && [ -x "$LIGHTEVAL_PY" ]; then
-                                "$LIGHTEVAL_PY" -c '"'"'import torch; print(f"torch={{torch.__version__}} cuda_build={{torch.version.cuda}} cuda_available={{torch.cuda.is_available()}} device_count={{torch.cuda.device_count()}}")'"'"' || true
-                            fi
-                        fi
-                    '
-            fi
-            echo "----------------------------------------------------"
-            echo
 
             if [ -n "$VENV_PATH" ]; then
                 source "$VENV_PATH/bin/activate"

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -266,6 +266,24 @@ def _lookup_dataset_specs_for_tasks(task_names: Iterable[str]) -> list[DatasetSp
     return specs
 
 
+def _build_task_suite_map() -> dict[str, str]:
+    """Build a mapping from task names to their suite from all task groups."""
+    data = (
+        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
+    )
+
+    task_suite_map: dict[str, str] = {}
+    for _, group_data in data.get("task_groups", {}).items():
+        group_suite = group_data.get("suite", "lm-eval-harness")
+        for task_data in group_data.get("tasks", []):
+            task_name = task_data.get("task")
+            task_suite = task_data.get("suite", group_suite)
+            if task_name and task_name not in task_suite_map:
+                task_suite_map[task_name] = task_suite
+
+    return task_suite_map
+
+
 def get_all_task_group_names() -> list[str]:
     """Return all available task group names (excluding super_groups)."""
     data = (


### PR DESCRIPTION
# Purpose
Enable running belebele_cf tasks on the Leonardo HPC cluster while improving resource handling and evaluation stability under SLURM.
Also fixed some functionality in `collect-results` to collect these results.

# Key Changes
- Added belebele_cf task list, which are belebele but with accuracy calculated using CF ([cloze](https://arxiv.org/html/2406.08446v2)/[classification](https://huggingface.co/docs/lighteval/v0.13.0/en/contributing-to-multilingual-evaluations#classification-formulation-cf) formulation.)
- Added explicit SLURM memory request logic to prevent OOM kills during large multilingual evaluation runs. This ensures jobs request sufficient RAM before launch. Fixes silent termination errors like:
```
0it [00:00, ?it/s][2026-04-13 13:27:07,695] [    INFO]: Detecting largest batch size with max_input_length=337 (transformers_model.py:500)
/var/spool/slurmd/job39737910/slurm_script: line 130: 906534 Killed                  lighteval accelerate "model_name=$model_path,trust_remote_code=True" "$LIGHT_TASK_ARG" --load-tasks-multilingual --output-dir "$RESULTS_SUBDIR" ${LIMIT:+--max-samples $LIMIT}
slurmstepd: error: Detected 1 oom_kill event in StepId=39737910.batch. Some of the step tasks have been OOM Killed.
```

- Lighteval batch-size now defaults to 1 for local runs (CPU or limited GPU) and 32 for cluster runs (Leonardo or similar SLURM environments.) Can also be override by environmental variable. This addresses CUDA out of memory errors.

- `collect-results` now searches for nested json under `results/`; support `acc-norm` metric collection; extracts `n_shot` from task name (which is the case for lighteval tasks) if it's not present otherwise. 

# Known Limitations
Below lighteval fixes aren't merged by upstream yet. For now, the workaround is to make lighteval patches in our own `.venv` and use `--venv_path .venv` in the evaluation script to make it effective.

- Incomplete Belebele language coverage  
Four languages currently fail due to missing translation literals in lighteval: Latvian, Slovenian, Lithuanian, Maltese
Each raises:
```
AttributeError: Translation for 'answer' is needed for Language.<LANG>.  Please provide its implementation by editing the 'src/lighteval/tasks/templates/utils/translation_literals.py'
```
To fix this, update `src/lighteval/tasks/templates/utils/translation_literals.py` to add support for these languages.

- belebele_cf triggers an LogProbTokenNorm IndexError intrinsic in lighteval (Issue [#1170](https://github.com/huggingface/lighteval/issues/1170)) when choices_tokens is shorter than choices_logprob. 
To fix this, edit [‎src/lighteval/metrics/normalizations.py‎](https://github.com/huggingface/lighteval/pull/1171/changes#diff-888ac06aac67024dd02b0f87e6ac8e95de072e7f5700eb12103cb315ebf7f660) according to their PR [#1171](https://github.com/huggingface/lighteval/pull/1171).
