### PR TITLE
collect-results: recursive multi-dir merge with duplicate override

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,17 +147,32 @@ If you use custom tasks via `--tasks` that are not in the task groups registry, 
 
 ## Collecting Results
 
-After evaluations complete, collect results into a CSV:
+After evaluations complete, collect results into a CSV.  `collect-results` **recursively** searches the given directory for every `jobs.csv` file and every `.json` result file, so you can point it at a top-level output folder that contains many sub-runs:
 
-```bash
-# Basic collection
-oellm collect-results --results_dir /path/to/eval-output-dir
-
-# Check for missing evaluations and create a CSV for re-running them
-oellm collect-results --results_dir /path/to/eval-output-dir --check true --output_csv results.csv
+```
+output/
+├── hellaswag_mt1/
+│   ├── jobs.csv
+│   └── results/
+├── hellaswag_mt2/
+│   ├── jobs.csv
+│   └── results/
+└── global_mmlu1/
+    ├── jobs.csv
+    └── results/
 ```
 
-The `--check` flag compares completed results against `jobs.csv` and outputs a `results_missing.csv` that can be used to re-schedule failed jobs:
+```bash
+# Merge all results found anywhere under the directory
+oellm collect-results --results_dir /path/to/output
+
+# Check for missing evaluations and create a CSV for re-running them
+oellm collect-results --results_dir /path/to/output --check true --output_csv results.csv
+```
+
+All `jobs.csv` files found under `results_dir` are merged into one; if the same `(model_path, task_path, n_shot)` row appears in multiple files the later-sorted entry wins (override duplicates). The merged jobs list is then compared against all `.json` result files found recursively.
+
+The `--check` flag outputs a `results_missing.csv` that can be used to re-schedule failed jobs:
 
 ```bash
 oellm schedule-eval --eval_csv_path results_missing.csv

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -523,8 +523,18 @@ def collect_results(
     """
     Collect evaluation results from JSON files and export to CSV.
 
+    Recursively searches ``results_dir`` for every sub-directory that contains
+    a ``jobs.csv`` file, merges all those CSV files into one (later directories
+    override duplicate rows), then recursively finds every ``.json`` result
+    file under ``results_dir``.
+
+    With ``--check`` the merged jobs are compared against the extracted results
+    and any missing evaluations are written to a ``*_missing.csv`` file.
+    Without ``--check`` the results are simply merged and written to
+    ``output_csv``.
+
     Args:
-        results_dir: Path to the directory containing result JSON files
+        results_dir: Root directory to search for jobs.csv files and JSON results
         output_csv: Output CSV filename (default: eval_results.csv)
         check: Check for missing evaluations and create a missing jobs CSV
         verbose: Enable verbose logging
@@ -593,30 +603,38 @@ def collect_results(
     if not results_path.exists():
         raise ValueError(f"Results directory does not exist: {results_dir}")
 
-    # Check if we need to look in a 'results' subdirectory
-    if (results_path / "results").exists() and (results_path / "results").is_dir():
-        # User passed the top-level directory, look in results subdirectory for nested json files
-        json_files = list((results_path / "results").rglob("*.json"))
+    # ------------------------------------------------------------------
+    # 1. Find all directories containing jobs.csv and merge them.
+    #    Directories are sorted so that deeper / later-alphabetical paths
+    #    are processed last, meaning their rows override earlier duplicates.
+    # ------------------------------------------------------------------
+    jobs_csv_paths = sorted(results_path.rglob("jobs.csv"))
+    if jobs_csv_paths:
+        logging.info(f"Found {len(jobs_csv_paths)} jobs.csv file(s): {[str(p) for p in jobs_csv_paths]}")
+        jobs_frames = [pd.read_csv(p) for p in jobs_csv_paths]
+        # Concatenate and let later entries win for duplicate (model_path, task_path, n_shot).
+        jobs_df = pd.concat(jobs_frames, ignore_index=True)
+        dup_cols = [c for c in ("model_path", "task_path", "n_shot") if c in jobs_df.columns]
+        if dup_cols:
+            jobs_df = jobs_df.drop_duplicates(subset=dup_cols, keep="last")
+        logging.info(f"Merged jobs.csv: {len(jobs_df)} unique jobs")
     else:
-        # User passed the results directory directly
-        json_files = list(results_path.glob("*.json"))
+        jobs_df = None
+        if check:
+            logging.warning(f"No jobs.csv found under {results_dir}, cannot perform check")
+            check = False
+
+    # ------------------------------------------------------------------
+    # 2. Recursively find all JSON result files.
+    # ------------------------------------------------------------------
+    json_files = sorted(results_path.rglob("*.json"))
 
     if not json_files:
-        logging.warning(f"No JSON files found in {results_dir}")
+        logging.warning(f"No JSON files found under {results_dir}")
         if not check:
             return
 
-    logging.info(f"Found {len(json_files)} result files")
-
-    # If check mode, also load the jobs.csv to compare
-    if check:
-        jobs_csv_path = results_path / "jobs.csv"
-        if not jobs_csv_path.exists():
-            logging.warning(f"No jobs.csv found in {results_dir}, cannot perform check")
-            check = False
-        else:
-            jobs_df = pd.read_csv(jobs_csv_path)
-            logging.info(f"Found {len(jobs_df)} scheduled jobs in jobs.csv")
+    logging.info(f"Found {len(json_files)} result file(s)")
 
     # Collect results
     rows = []

--- a/tests/test_collect_results.py
+++ b/tests/test_collect_results.py
@@ -1,0 +1,285 @@
+"""Tests for collect_results – mirrors the output/ folder layout used in practice.
+
+Typical on-disk structure that these tests reproduce:
+
+    output_root/
+        hellaswag_mt1/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        hellaswag_mt2/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        global_mmlu1/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        2026-04-28-no-results/
+            jobs.csv            ← jobs.csv present but no results dir yet
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from oellm.main import collect_results
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MODEL_A = "/cache/hub/model-a/snapshots/aaa"
+MODEL_B = "/cache/hub/model-b/snapshots/bbb"
+
+
+def _write_jobs_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def _lmeval_result(model_name: str, task: str, score: float, n_shot: int = 10) -> dict:
+    """Minimal lm-eval result JSON matching the real schema."""
+    return {
+        "model_name": model_name,
+        "results": {
+            task: {
+                "alias": task,
+                "acc,none": score,
+                "acc_stderr,none": 0.005,
+            }
+        },
+        "group_subtasks": {task: []},
+        "n-shot": {task: n_shot},
+    }
+
+
+def _write_result_json(results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 10) -> None:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    safe = model_name.replace("/", "_")
+    (results_dir / f"{safe}_{task}.json").write_text(
+        json.dumps(_lmeval_result(model_name, task, score, n_shot))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def output_root(tmp_path: Path) -> Path:
+    """
+    Builds a directory tree that mirrors the real output/ folder:
+
+        hellaswag_mt1/  – 2 models × 1 task each, both results present
+        hellaswag_mt2/  – 1 model × 1 task, result present
+        global_mmlu1/   – 1 model × 1 task, result present
+        2026-04-28/     – jobs.csv only, no results directory yet
+    """
+    root = tmp_path / "output"
+
+    # hellaswag_mt1 --------------------------------------------------------
+    mt1 = root / "hellaswag_mt1"
+    _write_jobs_csv(mt1 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        {"model_path": MODEL_B, "task_path": "hellaswag_nl", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mt1 / "results", MODEL_A, "hellaswag_da", 0.63)
+    _write_result_json(mt1 / "results", MODEL_B, "hellaswag_nl", 0.61)
+
+    # hellaswag_mt2 --------------------------------------------------------
+    mt2 = root / "hellaswag_mt2"
+    _write_jobs_csv(mt2 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_fr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mt2 / "results", MODEL_A, "hellaswag_fr", 0.59)
+
+    # global_mmlu1 ---------------------------------------------------------
+    mmlu1 = root / "global_mmlu1"
+    _write_jobs_csv(mmlu1 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "global_mmlu_full_de", "n_shot": 5, "eval_suite": "lm-eval-harness"},
+        {"model_path": MODEL_B, "task_path": "global_mmlu_full_en", "n_shot": 5, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mmlu1 / "results", MODEL_A, "global_mmlu_full_de", 0.52, n_shot=5)
+    _write_result_json(mmlu1 / "results", MODEL_B, "global_mmlu_full_en", 0.55, n_shot=5)
+
+    # 2026-04-28 – has jobs.csv but no results yet -------------------------
+    pending = root / "2026-04-28"
+    _write_jobs_csv(pending / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_sr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCollectResultsMerge:
+    """Results are gathered from all sub-directories and merged."""
+
+    def test_output_csv_created(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        assert Path(out_csv).exists()
+
+    def test_all_results_present(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        # 5 result JSONs were written across all subdirs
+        assert len(df) == 5
+
+    def test_correct_tasks_extracted(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        tasks = set(df["task"])
+        assert tasks == {"hellaswag_da", "hellaswag_nl", "hellaswag_fr", "global_mmlu_full_de", "global_mmlu_full_en"}
+
+    def test_correct_scores(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        row = df[df["task"] == "hellaswag_da"].iloc[0]
+        assert abs(row["performance"] - 0.63) < 1e-6
+
+    def test_n_shot_preserved(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert set(df[df["task"] == "global_mmlu_full_de"]["n_shot"]) == {5}
+
+
+class TestCollectResultsDuplicateOverride:
+    """When the same (model_path, task_path, n_shot) row appears in multiple
+    jobs.csv files the last-sorted entry wins."""
+
+    def test_duplicate_jobs_deduplicated(self, tmp_path):
+        root = tmp_path / "output"
+
+        # Two subdirectories both schedule the same job
+        for subdir_name in ["2026-05-01", "2026-05-02"]:
+            sub = root / subdir_name
+            _write_jobs_csv(sub / "jobs.csv", [
+                {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+            ])
+
+        _write_result_json(root / "2026-05-02" / "results", MODEL_A, "hellaswag_da", 0.65)
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv, check=True)
+
+        # Even though two jobs.csv files declare the same job, the merged jobs
+        # table should contain exactly one row for that combination.
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists(), "Job counted as missing despite result being present"
+
+    def test_result_duplicate_rows_not_doubled(self, tmp_path):
+        """If the same JSON appears (e.g. symlink / copy), the output still has 1 row per result file."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+        _write_result_json(sub / "results", MODEL_A, "hellaswag_da", 0.63)
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert len(df) == 1
+
+
+class TestCollectResultsCheckMode:
+    """--check compares merged results against merged jobs and writes _missing.csv."""
+
+    def test_all_complete_no_missing_csv(self, output_root, tmp_path):
+        """All jobs in `output_root` except the pending dir have results already."""
+        # The fixture has hellaswag_sr scheduled but no result JSON
+        # Remove the pending jobs.csv to get a fully-complete run
+        (output_root / "2026-04-28" / "jobs.csv").unlink()
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists()
+
+    def test_missing_jobs_written_to_csv(self, output_root, tmp_path):
+        """hellaswag_sr is in jobs.csv but has no result JSON → appears in missing CSV."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert Path(missing_csv).exists()
+        missing_df = pd.read_csv(missing_csv)
+        assert len(missing_df) >= 1
+        assert "hellaswag_sr" in missing_df["task_path"].values
+
+    def test_missing_csv_columns(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        missing_df = pd.read_csv(missing_csv)
+        for col in ("model_path", "task_path", "n_shot"):
+            assert col in missing_df.columns
+
+    def test_check_without_any_jobs_csv(self, tmp_path):
+        """If no jobs.csv exists anywhere, check mode is silently disabled."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_result_json(sub / "results", MODEL_A, "hellaswag_da", 0.63)
+
+        out_csv = str(tmp_path / "results.csv")
+        # Should not raise even though check=True and no jobs.csv exists
+        collect_results(str(root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists()
+
+
+class TestCollectResultsEdgeCases:
+    def test_no_json_files_returns_without_output(self, tmp_path):
+        root = tmp_path / "output"
+        sub = root / "2026-04-28"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        assert not Path(out_csv).exists()
+
+    def test_nonexistent_results_dir_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            collect_results(str(tmp_path / "nonexistent"))
+
+    def test_groups_json_extracted(self, tmp_path):
+        """JSON files that use the 'groups' key (lm-eval aggregate) are handled."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+
+        results_dir = sub / "results"
+        results_dir.mkdir(parents=True)
+        group_json = {
+            "model_name": MODEL_A,
+            "results": {},
+            "groups": {
+                "hellaswag_da": {"acc,none": 0.70, "acc_stderr,none": 0.01}
+            },
+            "group_subtasks": {"hellaswag_da": []},
+            "n-shot": {"hellaswag_da": 10},
+        }
+        (results_dir / "group_result.json").write_text(json.dumps(group_json))
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert len(df) == 1
+        assert abs(df.iloc[0]["performance"] - 0.70) < 1e-6


### PR DESCRIPTION
Implemented Issue #52!

- Recursively search results_dir for all jobs.csv files instead of requiring a single top-level jobs.csv
- Merge all found jobs.csv files into one DataFrame; later-sorted paths win for duplicate (model_path, task_path, n_shot) rows
- Recursively search for all .json result files instead of only looking one level deep or in a hardcoded 'results/' subdirectory
- --check: compare merged results against merged jobs, write _missing.csv; if no jobs.csv found anywhere, check mode is silently disabled
- Without --check: simply merge and write output_csv
- Update README.md Collecting Results section to document new behaviour
- Add tests/test_collect_results.py with 14 tests covering merge, duplicate override, check mode, and edge cases