### PR TITLE
Added Arc challenge MT

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_bg.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_bg.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_bg
+dataset_name: bg

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_cs.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_cs.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_cs
+dataset_name: cs

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_da.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_da.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_da
+dataset_name: da

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_de.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_de.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_de
+dataset_name: de

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_el.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_el.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_el
+dataset_name: el

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_es.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_es.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_es
+dataset_name: es

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_et.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_et.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_et
+dataset_name: et

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_fi.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_fi.yaml
@@ -1,0 +1,23 @@
+tag:
+  - arc_challenge_mt
+task: arc_challenge_mt_fi
+dataset_path: LumiOpen/arc_challenge_mt
+dataset_name: fi
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "Question: {{question}}\nAnswer:"
+doc_to_target: "{{choices.label.index(answerKey)}}"
+doc_to_choice: "{{choices.text}}"
+should_decontaminate: true
+doc_to_decontamination_query: "Question: {{question}}\nAnswer:"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_fr.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_fr.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_fr
+dataset_name: fr

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_hu.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_hu.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_hu
+dataset_name: hu

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_is.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_is.yaml
@@ -1,0 +1,22 @@
+tag:
+  - arc_challenge_mt
+task: arc_challenge_mt_is
+dataset_path: mideind/icelandic-arc-challenge
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "Question: {{question}}\nAnswer:"
+doc_to_target: "{{choices.label.index(answerKey)}}"
+doc_to_choice: "{{choices.text}}"
+should_decontaminate: true
+doc_to_decontamination_query: "Question: {{question}}\nAnswer:"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_it.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_it.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_it
+dataset_name: it

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_lt.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_lt.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_lt
+dataset_name: lt

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_lv.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_lv.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_lv
+dataset_name: lv

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_nb.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_nb.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_nb
+dataset_name: nb

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_nl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_nl.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_nl
+dataset_name: nl

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_pl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_pl.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_pl
+dataset_name: pl

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_pt.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_pt.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_pt
+dataset_name: pt

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_ro.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_ro.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_ro
+dataset_name: ro

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_sk.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_sk.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_sk
+dataset_name: sk

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_sl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_sl.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_sl
+dataset_name: sl

--- a/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_sv.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/arc_mt/arc_challenge_mt_sv.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_sv
+dataset_name: sv

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -52,6 +52,7 @@ task_metrics:
   arc_challenge_mt_sl: acc_norm
   arc_challenge_mt_es: acc_norm
   arc_challenge_mt_sv: acc_norm
+  arc_challenge_mt_is: acc_norm
   arc_challenge_mt_nb: acc_norm
   boolq: acc
   commonsense_qa: acc
@@ -494,7 +495,7 @@ task_groups:
       #   dataset: openaccess-ai-collective/jeopardy
 
   arc-challenge-mt-eu:
-    description: "ARC Challenge multilingual (21 European languages)"
+    description: "ARC Challenge multilingual (22 European languages)"
     suite: lm-eval-harness
     n_shots: [0]
     dataset: LumiOpen/arc_challenge_mt
@@ -539,6 +540,7 @@ task_groups:
         subset: es
       - task: arc_challenge_mt_sv
         subset: sv
+      - task: arc_challenge_mt_is
       - task: arc_challenge_mt_nb
         subset: nb
 

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -32,6 +32,28 @@ task_metrics:
   winogrande: acc
   arc_challenge: acc_norm
   arc_easy: acc_norm
+  arc_challenge_mt_bg: acc_norm
+  arc_challenge_mt_cs: acc_norm
+  arc_challenge_mt_da: acc_norm
+  arc_challenge_mt_nl: acc_norm
+  arc_challenge_mt_en: acc_norm
+  arc_challenge_mt_et: acc_norm
+  arc_challenge_mt_fi: acc_norm
+  arc_challenge_mt_fr: acc_norm
+  arc_challenge_mt_de: acc_norm
+  arc_challenge_mt_el: acc_norm
+  arc_challenge_mt_hu: acc_norm
+  arc_challenge_mt_it: acc_norm
+  arc_challenge_mt_lv: acc_norm
+  arc_challenge_mt_lt: acc_norm
+  arc_challenge_mt_pl: acc_norm
+  arc_challenge_mt_pt: acc_norm
+  arc_challenge_mt_ro: acc_norm
+  arc_challenge_mt_sk: acc_norm
+  arc_challenge_mt_sl: acc_norm
+  arc_challenge_mt_es: acc_norm
+  arc_challenge_mt_sv: acc_norm
+  arc_challenge_mt_nb: acc_norm
   boolq: acc
   commonsense_qa: acc
   hellaswag: acc_norm
@@ -471,6 +493,57 @@ task_groups:
       # - task: jeopardy
       #   n_shots: [10]
       #   dataset: openaccess-ai-collective/jeopardy
+
+  arc-challenge-mt-eu:
+    description: "ARC Challenge multilingual (22 European languages)"
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: LumiOpen/arc_challenge_mt
+    tasks:
+      - task: arc_challenge_mt_bg
+        subset: bg
+      - task: arc_challenge_mt_cs
+        subset: cs
+      - task: arc_challenge_mt_da
+        subset: da
+      - task: arc_challenge_mt_nl
+        subset: nl
+      - task: arc_challenge_mt_en
+        subset: en
+      - task: arc_challenge_mt_et
+        subset: et
+      - task: arc_challenge_mt_fi
+        subset: fi
+      - task: arc_challenge_mt_fr
+        subset: fr
+      - task: arc_challenge_mt_de
+        subset: de
+      - task: arc_challenge_mt_el
+        subset: el
+      - task: arc_challenge_mt_hu
+        subset: hu
+      - task: arc_challenge_mt_it
+        subset: it
+      - task: arc_challenge_mt_lv
+        subset: lv
+      - task: arc_challenge_mt_lt
+        subset: lt
+      - task: arc_challenge_mt_pl
+        subset: pl
+      - task: arc_challenge_mt_pt
+        subset: pt
+      - task: arc_challenge_mt_ro
+        subset: ro
+      - task: arc_challenge_mt_sk
+        subset: sk
+      - task: arc_challenge_mt_sl
+        subset: sl
+      - task: arc_challenge_mt_es
+        subset: es
+      - task: arc_challenge_mt_sv
+        subset: sv
+      - task: arc_challenge_mt_nb
+        subset: nb
 
   reasoning:
     description: "Reasoning tasks: GSM8k (4-shot), IFEval (0-shot), MBPP (3-shot), GPQA-Diamond (0-shot), MATH500 (0-shot), LiveCodeBench (0-shot)"

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -36,7 +36,6 @@ task_metrics:
   arc_challenge_mt_cs: acc_norm
   arc_challenge_mt_da: acc_norm
   arc_challenge_mt_nl: acc_norm
-  arc_challenge_mt_en: acc_norm
   arc_challenge_mt_et: acc_norm
   arc_challenge_mt_fi: acc_norm
   arc_challenge_mt_fr: acc_norm
@@ -495,7 +494,7 @@ task_groups:
       #   dataset: openaccess-ai-collective/jeopardy
 
   arc-challenge-mt-eu:
-    description: "ARC Challenge multilingual (22 European languages)"
+    description: "ARC Challenge multilingual (21 European languages)"
     suite: lm-eval-harness
     n_shots: [0]
     dataset: LumiOpen/arc_challenge_mt
@@ -508,8 +507,6 @@ task_groups:
         subset: da
       - task: arc_challenge_mt_nl
         subset: nl
-      - task: arc_challenge_mt_en
-        subset: en
       - task: arc_challenge_mt_et
         subset: et
       - task: arc_challenge_mt_fi


### PR DESCRIPTION
## Add `arc-challenge-mt-eu` evaluation task group

Adds the [LumiOpen/arc_challenge_mt](https://huggingface.co/datasets/LumiOpen/arc_challenge_mt) benchmark as an oellm task group, covering 22 European languages via `lm-eval-harness`.

### Changes

**`oellm/resources/task-groups.yaml`**
- Added 22 entries to `task_metrics` (`arc_challenge_mt_<lang>: acc_norm`) for: `bg`, `cs`, `da`, `nl`, `et`, `fi`, `fr`, `de`, `el`, `hu`, `it`, `lv`, `lt`, `pl`, `pt`, `ro`, `sk`, `sl`, `es`, `sv`, `nb`, `is`
- Added new task group `arc-challenge-mt-eu` with `suite: lm-eval-harness`, `n_shots: [0]`, `dataset: LumiOpen/arc_challenge_mt`

**`oellm/resources/custom_lm_eval_tasks/arc_mt/`** *(new directory)*
- Bundled 21 task YAML definitions (one per language). These are sourced from the LumiOpen lm-evaluation-harness fork and are required since the upstream `lm-eval` package does not include them. They are automatically passed to lm-eval via the existing `--include_path` mechanism.

### Notes
- English (`en`) is excluded — the `LumiOpen/arc_challenge_mt` dataset does not contain an English subset.
- openeurollm/datamix-9b-80-20 scores an average of 40.6% acc_norm across the 22 arc-challenge-mt-eu languages (0-shot).