### PR TITLE
Added opensubtitles-eu

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/_opensubtitles_multi40_common.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/_opensubtitles_multi40_common.yaml
@@ -1,0 +1,30 @@
+# Shared config for OpenSubtitles multilingual translation tasks.
+# Included by pairs/*.yaml files.
+output_type: generate_until
+custom_dataset: !function utils.load_opensubtitles_parallel
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+test_split: devtest
+target_delimiter: ''
+generation_kwargs:
+  until:
+    - "\n"
+    - "<|im_end|>"
+    - "</s>"
+    - "<|endoftext|>"
+    - "<|eot_id|>"
+    - "<|end_of_text|>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 128
+metric_list:
+  - metric: bleu
+    aggregation: bleu
+    higher_is_better: true
+  - metric: chrf
+    aggregation: chrf
+    higher_is_better: true
+metadata:
+  version: 1
+  dataset_dir: Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies
+  split: devtest

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/bg_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/bg_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_bg_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "bg"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/cs_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/cs_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_cs_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "cs"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/da_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/da_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_da_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "da"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/de_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/de_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_de_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "de"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/el_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/el_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_el_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "el"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_bg.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_bg.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_bg
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "bg"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_cs.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_cs.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_cs
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "cs"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_da.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_da.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_da
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "da"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_de.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_de.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_de
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "de"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_el.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_el.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_el
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "el"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_es.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_es.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_es
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "es"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_et.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_et.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_et
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "et"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_fi.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_fi.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_fi
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "fi"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_fr.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_fr.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_fr
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "fr"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_hr.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_hr.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_hr
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "hr"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_hu.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_hu.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_hu
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "hu"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_it.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_it.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_it
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "it"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_lt.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_lt.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_lt
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "lt"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_lv.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_lv.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_lv
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "lv"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_nl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_nl.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_nl
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "nl"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_no.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_no.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_no
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "no"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_pl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_pl.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_pl
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "pl"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_pt.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_pt.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_pt
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "pt"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_ro.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_ro.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_ro
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "ro"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sk.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sk.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_sk
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "sk"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sl.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_sl
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "sl"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sr.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sr.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_sr
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "sr"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sv.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_sv.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_sv
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "sv"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_tr.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_tr.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_tr
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "tr"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_uk.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/en_to_uk.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_en_to_uk
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "en"
+  tgt_lang: "uk"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/es_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/es_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_es_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "es"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/et_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/et_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_et_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "et"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/fi_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/fi_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_fi_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "fi"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/fr_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/fr_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_fr_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "fr"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/hr_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/hr_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_hr_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "hr"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/hu_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/hu_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_hu_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "hu"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/it_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/it_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_it_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "it"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/lt_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/lt_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_lt_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "lt"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/lv_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/lv_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_lv_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "lv"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/nl_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/nl_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_nl_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "nl"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/no_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/no_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_no_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "no"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/pl_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/pl_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_pl_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "pl"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/pt_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/pt_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_pt_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "pt"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/ro_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/ro_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_ro_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "ro"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sk_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sk_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_sk_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "sk"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sl_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sl_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_sl_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "sl"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sr_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sr_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_sr_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "sr"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sv_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/sv_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_sv_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "sv"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/tr_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/tr_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_tr_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "tr"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/uk_to_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/pairs/uk_to_en.yaml
@@ -1,0 +1,8 @@
+include: ../_opensubtitles_multi40_common.yaml
+task: opensubtitles_multi40_uk_to_en
+metadata:
+  version: 1
+  dataset_dir: "Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies"
+  split: "devtest"
+  src_lang: "uk"
+  tgt_lang: "en"

--- a/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/utils.py
+++ b/oellm/resources/custom_lm_eval_tasks/opensubtitles_multi40/utils.py
@@ -1,0 +1,306 @@
+import logging
+import os
+
+import datasets
+from huggingface_hub import snapshot_download
+
+eval_logger = logging.getLogger(__name__)
+
+_LANG_CODE_TO_NAME = {
+    "ar": "Arabic",
+    "bg": "Bulgarian",
+    "cs": "Czech",
+    "da": "Danish",
+    "de": "German",
+    "el": "Greek",
+    "en": "English",
+    "es": "Spanish",
+    "et": "Estonian",
+    "fa": "Persian",
+    "fi": "Finnish",
+    "fr": "French",
+    "he": "Hebrew",
+    "hi": "Hindi",
+    "hr": "Croatian",
+    "hu": "Hungarian",
+    "id": "Indonesian",
+    "it": "Italian",
+    "ko": "Korean",
+    "lt": "Lithuanian",
+    "lv": "Latvian",
+    "ms": "Malay",
+    "nl": "Dutch",
+    "no": "Norwegian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "pt_BR": "Portuguese (Brazil)",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "sk": "Slovak",
+    "sl": "Slovenian",
+    "sr": "Serbian",
+    "sv": "Swedish",
+    "ta": "Tamil",
+    "te": "Telugu",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "vi": "Vietnamese",
+    "zh_CN": "Chinese (Simplified)",
+    "zh_TW": "Chinese (Traditional)",
+}
+
+_META_COLUMNS = {
+    "id",
+    "movie_id",
+    "segment_id",
+    "doc_id",
+    "line_number",
+    "source",
+    "timestamp_start",
+    "timestamp_end",
+    "speaker",
+    "translation",
+}
+
+# In-process caches to avoid reloading the same dataset split for each subtask.
+_DATASET_SPLIT_CACHE = {}
+_LANGUAGES_CACHE = {}
+
+
+def _safe_str(value):
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _select_split(dataset_obj, split, dataset_ref):
+    if isinstance(dataset_obj, datasets.DatasetDict):
+        if split in dataset_obj:
+            return dataset_obj[split]
+        if len(dataset_obj) == 1:
+            only_split = next(iter(dataset_obj.keys()))
+            eval_logger.warning(
+                "Requested split %s not found in %s. Falling back to only split %s.",
+                split,
+                dataset_ref,
+                only_split,
+            )
+            return dataset_obj[only_split]
+        raise ValueError(
+            f"Split {split} not found in dataset. Available splits: {list(dataset_obj.keys())}"
+        )
+
+    if isinstance(dataset_obj, datasets.Dataset):
+        eval_logger.warning(
+            "Loaded a Dataset (not DatasetDict) from %s. Using it directly.",
+            dataset_ref,
+        )
+        return dataset_obj
+
+    raise TypeError(
+        f"Unsupported dataset object type from {dataset_ref}: {type(dataset_obj)}"
+    )
+
+
+def _load_split(dataset_ref, split):
+    ref = _safe_str(dataset_ref).strip()
+    if not ref:
+        raise ValueError("Empty dataset reference provided.")
+    split_name = _safe_str(split).strip()
+    cache_key = (ref, split_name)
+
+    cached = _DATASET_SPLIT_CACHE.get(cache_key)
+    if cached is not None:
+        eval_logger.debug("Using cached dataset for %s (split=%s).", ref, split_name)
+        return cached
+
+    expanded_ref = os.path.expanduser(ref)
+    if os.path.exists(expanded_ref):
+        dataset_obj = datasets.load_from_disk(expanded_ref)
+        selected = _select_split(dataset_obj, split_name, expanded_ref)
+        _DATASET_SPLIT_CACHE[cache_key] = selected
+        return selected
+
+    if ref.startswith("/") or ref.startswith(".") or ref.startswith("~"):
+        raise ValueError(f"Local dataset path does not exist: {ref}")
+
+    # HF dataset id: first try downloading snapshot and opening as save_to_disk.
+    try:
+        snapshot_path = snapshot_download(repo_id=ref, repo_type="dataset")
+        dataset_obj = datasets.load_from_disk(snapshot_path)
+        selected = _select_split(dataset_obj, split_name, ref)
+        _DATASET_SPLIT_CACHE[cache_key] = selected
+        return selected
+    except Exception:
+        # Fallback for standard Hub datasets published in load_dataset format.
+        try:
+            dataset = datasets.load_dataset(ref, split=split_name)
+            selected = _select_split(dataset, split_name, ref)
+            _DATASET_SPLIT_CACHE[cache_key] = selected
+            return selected
+        except Exception:
+            try:
+                dataset_obj = datasets.load_dataset(ref)
+                selected = _select_split(dataset_obj, split_name, ref)
+                _DATASET_SPLIT_CACHE[cache_key] = selected
+                return selected
+            except Exception as exc:
+                raise ValueError(
+                    f"Failed to load dataset reference {ref}. "
+                    "Provide a valid local save_to_disk path or a HF dataset id."
+                ) from exc
+
+
+def _infer_languages(dataset):
+    if "translation" in dataset.column_names:
+        translation_feature = dataset.features.get("translation")
+        if hasattr(translation_feature, "keys"):
+            return sorted(translation_feature.keys())
+
+        if len(dataset) == 0:
+            raise ValueError(
+                "Dataset is empty. Cannot infer language keys from translation."
+            )
+
+        first_translation = dataset[0].get("translation", {})
+        if not isinstance(first_translation, dict) or not first_translation:
+            raise ValueError(
+                "Column translation exists but does not contain a non-empty dict."
+            )
+        return sorted(first_translation.keys())
+
+    return sorted([col for col in dataset.column_names if col not in _META_COLUMNS])
+
+
+def _lang_display_name(lang_code):
+    code = _safe_str(lang_code)
+    if code in _LANG_CODE_TO_NAME:
+        return _LANG_CODE_TO_NAME[code]
+
+    normalized = code.replace("-", "_")
+    if normalized in _LANG_CODE_TO_NAME:
+        return _LANG_CODE_TO_NAME[normalized]
+
+    if "_" in normalized:
+        base, variant = normalized.split("_", 1)
+        if base in _LANG_CODE_TO_NAME:
+            return f"{_LANG_CODE_TO_NAME[base]} ({variant})"
+
+    return code
+
+
+def _extract_pair(doc, src_lang, tgt_lang):
+    if "translation" in doc and isinstance(doc["translation"], dict):
+        src_text = _safe_str(doc["translation"].get(src_lang, ""))
+        tgt_text = _safe_str(doc["translation"].get(tgt_lang, ""))
+        return src_text, tgt_text
+
+    src_text = _safe_str(doc.get(src_lang, ""))
+    tgt_text = _safe_str(doc.get(tgt_lang, ""))
+    return src_text, tgt_text
+
+
+def load_opensubtitles_parallel(**kwargs):
+    """
+    Custom dataset loader for OpenSubtitles multi-aligned data.
+
+    Expected kwargs (from metadata/dataset_kwargs):
+      - dataset_dir: local save_to_disk path OR HF dataset id
+      - split: split name to read from source dataset (default: devtest)
+      - output_split: split name returned to harness (default: split)
+      - src_lang: source language key (e.g. en)
+      - tgt_lang: target language key (e.g. fi)
+      - allow_empty: keep examples where src or tgt is empty (default: False)
+      - max_samples: optional int to truncate dataset for quick debugging
+    """
+    dataset_ref = kwargs.get("dataset_dir") or kwargs.get("dataset_repo")
+    if not dataset_ref:
+        raise ValueError("dataset_dir must be provided in metadata or dataset_kwargs.")
+
+    split = kwargs.get("split", "devtest")
+    output_split = kwargs.get("output_split", split)
+    src_lang = kwargs.get("src_lang")
+    tgt_lang = kwargs.get("tgt_lang")
+    allow_empty = bool(kwargs.get("allow_empty", False))
+    max_samples = kwargs.get("max_samples")
+
+    if not src_lang or not tgt_lang:
+        raise ValueError("Both src_lang and tgt_lang must be provided.")
+
+    dataset = _load_split(dataset_ref, split)
+    split_name = _safe_str(split).strip()
+    language_cache_key = (_safe_str(dataset_ref).strip(), split_name)
+    languages = _LANGUAGES_CACHE.get(language_cache_key)
+    if languages is None:
+        languages = _infer_languages(dataset)
+        _LANGUAGES_CACHE[language_cache_key] = languages
+
+    missing = [lang for lang in (src_lang, tgt_lang) if lang not in languages]
+    if missing:
+        raise ValueError(
+            f"Missing language(s) {missing} in dataset. Available languages: {languages}"
+        )
+
+    eval_logger.info(
+        "Loading OpenSubtitles translation direction %s -> %s from %s (split=%s)",
+        src_lang,
+        tgt_lang,
+        dataset_ref,
+        split,
+    )
+
+    def _has_valid_pair(doc):
+        src_text, tgt_text = _extract_pair(doc, src_lang, tgt_lang)
+        if allow_empty:
+            return True
+        return bool(src_text.strip()) and bool(tgt_text.strip())
+
+    dataset = dataset.filter(_has_valid_pair)
+
+    def _map_doc(doc):
+        src_text, tgt_text = _extract_pair(doc, src_lang, tgt_lang)
+
+        segment_raw = doc.get("segment_id", doc.get("line_number", -1))
+        try:
+            segment_id = int(segment_raw)
+        except (TypeError, ValueError):
+            segment_id = -1
+
+        return {
+            "id": _safe_str(doc.get("id", "")),
+            "movie_id": _safe_str(doc.get("movie_id", doc.get("doc_id", ""))),
+            "segment_id": segment_id,
+            "src_lang": src_lang,
+            "tgt_lang": tgt_lang,
+            "src": src_text,
+            "tgt": tgt_text,
+        }
+
+    dataset = dataset.map(_map_doc, remove_columns=dataset.column_names)
+
+    if max_samples is not None:
+        max_samples = int(max_samples)
+        dataset = dataset.select(range(min(max_samples, len(dataset))))
+
+    eval_logger.info(
+        "Prepared %d aligned samples for %s -> %s.",
+        len(dataset),
+        src_lang,
+        tgt_lang,
+    )
+
+    return {output_split: dataset}
+
+
+def doc_to_text(doc):
+    src_lang_name = _lang_display_name(doc.get("src_lang", ""))
+    tgt_lang_name = _lang_display_name(doc.get("tgt_lang", ""))
+    return "Translate the following sentence from {} to {}:\n{}\nTranslation:\n".format(
+        src_lang_name, tgt_lang_name, doc["src"]
+    )
+
+
+def doc_to_target(doc):
+    return doc["tgt"]

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -105,6 +105,56 @@ task_metrics:
   bigbench_operators_generate_until: exact_match
   bigbench_repeat_copy_logic_generate_until: exact_match
   bigbench_cs_algorithms_generate_until: exact_match
+  opensubtitles_multi40_en_to_bg: bleu
+  opensubtitles_multi40_en_to_hr: bleu
+  opensubtitles_multi40_en_to_cs: bleu
+  opensubtitles_multi40_en_to_da: bleu
+  opensubtitles_multi40_en_to_nl: bleu
+  opensubtitles_multi40_en_to_et: bleu
+  opensubtitles_multi40_en_to_fi: bleu
+  opensubtitles_multi40_en_to_fr: bleu
+  opensubtitles_multi40_en_to_de: bleu
+  opensubtitles_multi40_en_to_el: bleu
+  opensubtitles_multi40_en_to_hu: bleu
+  opensubtitles_multi40_en_to_it: bleu
+  opensubtitles_multi40_en_to_lv: bleu
+  opensubtitles_multi40_en_to_lt: bleu
+  opensubtitles_multi40_en_to_pl: bleu
+  opensubtitles_multi40_en_to_pt: bleu
+  opensubtitles_multi40_en_to_ro: bleu
+  opensubtitles_multi40_en_to_sk: bleu
+  opensubtitles_multi40_en_to_sl: bleu
+  opensubtitles_multi40_en_to_es: bleu
+  opensubtitles_multi40_en_to_sv: bleu
+  opensubtitles_multi40_en_to_sr: bleu
+  opensubtitles_multi40_en_to_tr: bleu
+  opensubtitles_multi40_en_to_uk: bleu
+  opensubtitles_multi40_en_to_no: bleu
+  opensubtitles_multi40_bg_to_en: bleu
+  opensubtitles_multi40_hr_to_en: bleu
+  opensubtitles_multi40_cs_to_en: bleu
+  opensubtitles_multi40_da_to_en: bleu
+  opensubtitles_multi40_nl_to_en: bleu
+  opensubtitles_multi40_et_to_en: bleu
+  opensubtitles_multi40_fi_to_en: bleu
+  opensubtitles_multi40_fr_to_en: bleu
+  opensubtitles_multi40_de_to_en: bleu
+  opensubtitles_multi40_el_to_en: bleu
+  opensubtitles_multi40_hu_to_en: bleu
+  opensubtitles_multi40_it_to_en: bleu
+  opensubtitles_multi40_lv_to_en: bleu
+  opensubtitles_multi40_lt_to_en: bleu
+  opensubtitles_multi40_pl_to_en: bleu
+  opensubtitles_multi40_pt_to_en: bleu
+  opensubtitles_multi40_ro_to_en: bleu
+  opensubtitles_multi40_sk_to_en: bleu
+  opensubtitles_multi40_sl_to_en: bleu
+  opensubtitles_multi40_es_to_en: bleu
+  opensubtitles_multi40_sv_to_en: bleu
+  opensubtitles_multi40_sr_to_en: bleu
+  opensubtitles_multi40_tr_to_en: bleu
+  opensubtitles_multi40_uk_to_en: bleu
+  opensubtitles_multi40_no_to_en: bleu
   global_piqa_completions_als_latn: acc_norm
   global_piqa_completions_bos_latn: acc_norm
   global_piqa_completions_bul_cyrl: acc_norm
@@ -445,6 +495,26 @@ task_groups:
       - task: jeopardy
         n_shots: [10]
         dataset: openeurollm/jeopardy
+
+  opensubtitles-eu-en-xx:
+    description: "OpenSubtitles Multi40 English->EU translation (0-shot, BLEU)."
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies
+    valid_langs: [bg, hr, cs, da, nl, et, fi, fr, de, el, hu, it, lv, lt, pl,
+                  pt, ro, sk, sl, es, sv, sr, tr, uk, "no"]
+    tasks:
+      - task: "opensubtitles_multi40_en_to_{lang}"
+
+  opensubtitles-eu-xx-en:
+    description: "OpenSubtitles Multi40 EU->English translation (0-shot, BLEU)."
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies
+    valid_langs: [bg, hr, cs, da, nl, et, fi, fr, de, el, hu, it, lv, lt, pl,
+                  pt, ro, sk, sl, es, sv, sr, tr, uk, "no"]
+    tasks:
+      - task: "opensubtitles_multi40_{lang}_to_en"
 
   arc-challenge-mt-eu:
     description: "ARC Challenge multilingual (22 European languages)"

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -44,6 +44,8 @@ _LANG_ALIAS = {
     "sl": "slv_Latn",
     "is": "isl_Latn",
     "nb": "nob_Latn",
+    "no": "nob_Latn",
+    "hr": "hrv_Latn",
     # full English names (include)
     "albanian": "als_Latn",
     "armenian": "hye_Armn",
@@ -97,15 +99,20 @@ def _canonical_language(code: str | None) -> str | None:
 def _resolve_task_languages(name: str, subset: str | None) -> list[str]:
     """Return the canonical language code(s) a task belongs to, if any.
 
-    Translation pairs (``flores200:src-tgt``) resolve to their non-English
-    side; every other task resolves via its ``subset``. Tasks with no
-    recognisable language (e.g. English-only standard benchmarks) return [].
+    Translation pairs (``flores200:src-tgt`` and
+    ``opensubtitles_multi40_src_to_tgt``) resolve to their non-English side;
+    every other task resolves via its ``subset``. Tasks with no recognisable
+    language (e.g. English-only standard benchmarks) return [].
     """
     if name.startswith("flores200:"):
         pair = name.split(":", 1)[1]
         langs = [
             _canonical_language(part) for part in pair.split("-") if part != "eng_Latn"
         ]
+        return [lang for lang in langs if lang]
+    if name.startswith("opensubtitles_multi40_"):
+        pair = name[len("opensubtitles_multi40_") :]
+        langs = [_canonical_language(part) for part in pair.split("_to_") if part != "en"]
         return [lang for lang in langs if lang]
     lang = _canonical_language(subset)
     if lang:


### PR DESCRIPTION
## Summary

I added **OpenSubtitles Multi40** translation as two `lm-evaluation-harness` groups — **`opensubtitles-eu-en-xx`** (English→EU) and **`opensubtitles-eu-xx-en`** (EU→English) — at 0-shot, scored with BLEU (chrF also computed), using the [Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies](https://huggingface.co/datasets/Helsinki-NLP/OpenSubtitles2024-40-langs-15-movies) dataset. OpenSubtitles isn't in lm-eval-harness or lighteval, so I vendored a custom loader + per-pair tasks under `custom_lm_eval_tasks/opensubtitles_multi40/`. One of the Evals from #89.

## Language coverage — EU subset only

The dataset ships 40 languages; **25 of them are in our EU set, and I include all 25** (each in both directions):

> Bulgarian, Croatian, Czech, Danish, Dutch, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Polish, Portuguese, Romanian, Slovak, Slovenian, Spanish, Swedish, Serbian, Turkish, Ukrainian, Norwegian

EU languages the dataset does **not** ship are omitted: Irish, Maltese, Catalan, Basque, Galician, Bosnian, Georgian, Macedonian, Albanian, Icelandic.

Both groups are `{lang}` templates with `valid_langs`. Since these are translation pairs, each task resolves to its **non-English side** (mirroring the `flores200` handling in `task_groups.py`), so `opensubtitles-eu-xx-en[deu_Latn]` correctly selects `de→en`. I also added the `hr`→`hrv_Latn` and `no`→`nob_Latn` aliases so Croatian and Norwegian resolve.

## Metric

`bleu` (sacrebleu), matching the custom task's `metric_list`.