### PR TITLE
Added Global piqa

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/_template
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/_template
@@ -1,0 +1,18 @@
+dataset_path: mrlbenchmarks/global-piqa-nonparallel
+output_type: multiple_choice
+test_split: test
+doc_to_text: prompt
+doc_to_target: label
+doc_to_choice: "{{[solution0, solution1]}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_bytes
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/als_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/als_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: als_latn
+include: _template
+task: global_piqa_completions_als_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/bos_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/bos_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: bos_latn
+include: _template
+task: global_piqa_completions_bos_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/bul_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/bul_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: bul_cyrl
+include: _template
+task: global_piqa_completions_bul_cyrl

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/cat_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/cat_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: cat_latn
+include: _template
+task: global_piqa_completions_cat_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ces_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ces_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ces_latn
+include: _template
+task: global_piqa_completions_ces_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/deu_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/deu_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: deu_latn
+include: _template
+task: global_piqa_completions_deu_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ekk_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ekk_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ekk_latn
+include: _template
+task: global_piqa_completions_ekk_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ell_grek.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ell_grek.yaml
@@ -1,0 +1,3 @@
+dataset_name: ell_grek
+include: _template
+task: global_piqa_completions_ell_grek

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/eng_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/eng_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: eng_latn
+include: _template
+task: global_piqa_completions_eng_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/fin_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/fin_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: fin_latn
+include: _template
+task: global_piqa_completions_fin_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/fra_latn_fran.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/fra_latn_fran.yaml
@@ -1,0 +1,3 @@
+dataset_name: fra_latn_fran
+include: _template
+task: global_piqa_completions_fra_latn_fran

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/glg_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/glg_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: glg_latn
+include: _template
+task: global_piqa_completions_glg_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/hrv_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/hrv_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: hrv_latn
+include: _template
+task: global_piqa_completions_hrv_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/hun_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/hun_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: hun_latn
+include: _template
+task: global_piqa_completions_hun_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/isl_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/isl_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: isl_latn
+include: _template
+task: global_piqa_completions_isl_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ita_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ita_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ita_latn
+include: _template
+task: global_piqa_completions_ita_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/kat_geor.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/kat_geor.yaml
@@ -1,0 +1,3 @@
+dataset_name: kat_geor
+include: _template
+task: global_piqa_completions_kat_geor

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/lit_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/lit_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: lit_latn
+include: _template
+task: global_piqa_completions_lit_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/mkd_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/mkd_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: mkd_cyrl
+include: _template
+task: global_piqa_completions_mkd_cyrl

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/nld_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/nld_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: nld_latn
+include: _template
+task: global_piqa_completions_nld_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/nno_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/nno_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: nno_latn
+include: _template
+task: global_piqa_completions_nno_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/nob_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/nob_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: nob_latn
+include: _template
+task: global_piqa_completions_nob_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/pol_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/pol_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: pol_latn
+include: _template
+task: global_piqa_completions_pol_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/por_latn_port.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/por_latn_port.yaml
@@ -1,0 +1,3 @@
+dataset_name: por_latn_port
+include: _template
+task: global_piqa_completions_por_latn_port

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ron_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ron_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ron_latn
+include: _template
+task: global_piqa_completions_ron_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/slk_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/slk_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: slk_latn
+include: _template
+task: global_piqa_completions_slk_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/slv_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/slv_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: slv_latn
+include: _template
+task: global_piqa_completions_slv_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/spa_latn_spai.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/spa_latn_spai.yaml
@@ -1,0 +1,3 @@
+dataset_name: spa_latn_spai
+include: _template
+task: global_piqa_completions_spa_latn_spai

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/srp_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/srp_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: srp_cyrl
+include: _template
+task: global_piqa_completions_srp_cyrl

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/swe_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/swe_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: swe_latn
+include: _template
+task: global_piqa_completions_swe_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/tur_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/tur_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: tur_latn
+include: _template
+task: global_piqa_completions_tur_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ukr_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/completions/ukr_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: ukr_cyrl
+include: _template
+task: global_piqa_completions_ukr_cyrl

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/_template
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/_template
@@ -1,0 +1,24 @@
+dataset_path: mrlbenchmarks/global-piqa-nonparallel
+output_type: generate_until
+test_split: test
+doc_to_text: "Given the following situation, which option is more likely to be correct?\n\nSituation:\n{{prompt}} ...\n\nOption A: {{solution0}}\n\nOption B: {{solution1}}\n\nYour response should end with \"The best answer is: [answer_letter]\" where [answer_letter] is one of A or B."
+doc_to_target: "{{['A', 'B'][label]}}"
+generation_kwargs:
+  do_sample: true
+  temperature: 0.8
+  top_p: 0.95
+  max_gen_toks: 2048
+  until: [ ]
+filter_list:
+  - name: strict_match
+    filter:
+      - function: "regex"
+        regex_pattern: '[Tt]he (?:[Bb]est [Aa]nswer|[Ff]inal [Aa]nswer|[Aa]nswer)[^A-B]*([A-B])|[Aa]nswer\s*:[^A-B]*([A-B])|\\boxed\{([A-B])\}'
+        group_select: -1
+      - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/_template
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/_template
@@ -7,7 +7,7 @@ generation_kwargs:
   do_sample: true
   temperature: 0.8
   top_p: 0.95
-  max_gen_toks: 2048
+  max_gen_toks: 256
   until: [ ]
 filter_list:
   - name: strict_match

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/als_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/als_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: als_latn
+include: _template
+task: global_piqa_prompted_als_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/bos_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/bos_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: bos_latn
+include: _template
+task: global_piqa_prompted_bos_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/bul_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/bul_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: bul_cyrl
+include: _template
+task: global_piqa_prompted_bul_cyrl

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/cat_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/cat_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: cat_latn
+include: _template
+task: global_piqa_prompted_cat_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ces_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ces_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ces_latn
+include: _template
+task: global_piqa_prompted_ces_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/deu_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/deu_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: deu_latn
+include: _template
+task: global_piqa_prompted_deu_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ekk_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ekk_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ekk_latn
+include: _template
+task: global_piqa_prompted_ekk_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ell_grek.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ell_grek.yaml
@@ -1,0 +1,3 @@
+dataset_name: ell_grek
+include: _template
+task: global_piqa_prompted_ell_grek

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/eng_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/eng_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: eng_latn
+include: _template
+task: global_piqa_prompted_eng_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/fin_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/fin_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: fin_latn
+include: _template
+task: global_piqa_prompted_fin_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/fra_latn_fran.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/fra_latn_fran.yaml
@@ -1,0 +1,3 @@
+dataset_name: fra_latn_fran
+include: _template
+task: global_piqa_prompted_fra_latn_fran

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/glg_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/glg_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: glg_latn
+include: _template
+task: global_piqa_prompted_glg_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/hrv_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/hrv_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: hrv_latn
+include: _template
+task: global_piqa_prompted_hrv_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/hun_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/hun_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: hun_latn
+include: _template
+task: global_piqa_prompted_hun_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/isl_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/isl_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: isl_latn
+include: _template
+task: global_piqa_prompted_isl_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ita_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ita_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ita_latn
+include: _template
+task: global_piqa_prompted_ita_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/kat_geor.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/kat_geor.yaml
@@ -1,0 +1,3 @@
+dataset_name: kat_geor
+include: _template
+task: global_piqa_prompted_kat_geor

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/lit_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/lit_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: lit_latn
+include: _template
+task: global_piqa_prompted_lit_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/mkd_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/mkd_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: mkd_cyrl
+include: _template
+task: global_piqa_prompted_mkd_cyrl

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/nld_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/nld_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: nld_latn
+include: _template
+task: global_piqa_prompted_nld_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/nno_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/nno_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: nno_latn
+include: _template
+task: global_piqa_prompted_nno_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/nob_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/nob_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: nob_latn
+include: _template
+task: global_piqa_prompted_nob_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/pol_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/pol_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: pol_latn
+include: _template
+task: global_piqa_prompted_pol_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/por_latn_port.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/por_latn_port.yaml
@@ -1,0 +1,3 @@
+dataset_name: por_latn_port
+include: _template
+task: global_piqa_prompted_por_latn_port

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ron_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ron_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: ron_latn
+include: _template
+task: global_piqa_prompted_ron_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/slk_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/slk_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: slk_latn
+include: _template
+task: global_piqa_prompted_slk_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/slv_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/slv_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: slv_latn
+include: _template
+task: global_piqa_prompted_slv_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/spa_latn_spai.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/spa_latn_spai.yaml
@@ -1,0 +1,3 @@
+dataset_name: spa_latn_spai
+include: _template
+task: global_piqa_prompted_spa_latn_spai

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/srp_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/srp_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: srp_cyrl
+include: _template
+task: global_piqa_prompted_srp_cyrl

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/swe_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/swe_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: swe_latn
+include: _template
+task: global_piqa_prompted_swe_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/tur_latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/tur_latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: tur_latn
+include: _template
+task: global_piqa_prompted_tur_latn

--- a/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ukr_cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/ukr_cyrl.yaml
@@ -1,0 +1,3 @@
+dataset_name: ukr_cyrl
+include: _template
+task: global_piqa_prompted_ukr_cyrl

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -47,6 +47,70 @@ task_metrics:
   bigbench_operators_generate_until: exact_match
   bigbench_repeat_copy_logic_generate_until: exact_match
   bigbench_cs_algorithms_generate_until: exact_match
+  global_piqa_completions_als_latn: acc_norm
+  global_piqa_completions_bos_latn: acc_norm
+  global_piqa_completions_bul_cyrl: acc_norm
+  global_piqa_completions_cat_latn: acc_norm
+  global_piqa_completions_ces_latn: acc_norm
+  global_piqa_completions_deu_latn: acc_norm
+  global_piqa_completions_ekk_latn: acc_norm
+  global_piqa_completions_ell_grek: acc_norm
+  global_piqa_completions_eng_latn: acc_norm
+  global_piqa_completions_fin_latn: acc_norm
+  global_piqa_completions_fra_latn_fran: acc_norm
+  global_piqa_completions_glg_latn: acc_norm
+  global_piqa_completions_hrv_latn: acc_norm
+  global_piqa_completions_hun_latn: acc_norm
+  global_piqa_completions_isl_latn: acc_norm
+  global_piqa_completions_ita_latn: acc_norm
+  global_piqa_completions_kat_geor: acc_norm
+  global_piqa_completions_lit_latn: acc_norm
+  global_piqa_completions_mkd_cyrl: acc_norm
+  global_piqa_completions_nld_latn: acc_norm
+  global_piqa_completions_nno_latn: acc_norm
+  global_piqa_completions_nob_latn: acc_norm
+  global_piqa_completions_pol_latn: acc_norm
+  global_piqa_completions_por_latn_port: acc_norm
+  global_piqa_completions_ron_latn: acc_norm
+  global_piqa_completions_slk_latn: acc_norm
+  global_piqa_completions_slv_latn: acc_norm
+  global_piqa_completions_spa_latn_spai: acc_norm
+  global_piqa_completions_srp_cyrl: acc_norm
+  global_piqa_completions_swe_latn: acc_norm
+  global_piqa_completions_tur_latn: acc_norm
+  global_piqa_completions_ukr_cyrl: acc_norm
+  global_piqa_prompted_als_latn: exact_match
+  global_piqa_prompted_bos_latn: exact_match
+  global_piqa_prompted_bul_cyrl: exact_match
+  global_piqa_prompted_cat_latn: exact_match
+  global_piqa_prompted_ces_latn: exact_match
+  global_piqa_prompted_deu_latn: exact_match
+  global_piqa_prompted_ekk_latn: exact_match
+  global_piqa_prompted_ell_grek: exact_match
+  global_piqa_prompted_eng_latn: exact_match
+  global_piqa_prompted_fin_latn: exact_match
+  global_piqa_prompted_fra_latn_fran: exact_match
+  global_piqa_prompted_glg_latn: exact_match
+  global_piqa_prompted_hrv_latn: exact_match
+  global_piqa_prompted_hun_latn: exact_match
+  global_piqa_prompted_isl_latn: exact_match
+  global_piqa_prompted_ita_latn: exact_match
+  global_piqa_prompted_kat_geor: exact_match
+  global_piqa_prompted_lit_latn: exact_match
+  global_piqa_prompted_mkd_cyrl: exact_match
+  global_piqa_prompted_nld_latn: exact_match
+  global_piqa_prompted_nno_latn: exact_match
+  global_piqa_prompted_nob_latn: exact_match
+  global_piqa_prompted_pol_latn: exact_match
+  global_piqa_prompted_por_latn_port: exact_match
+  global_piqa_prompted_ron_latn: exact_match
+  global_piqa_prompted_slk_latn: exact_match
+  global_piqa_prompted_slv_latn: exact_match
+  global_piqa_prompted_spa_latn_spai: exact_match
+  global_piqa_prompted_srp_cyrl: exact_match
+  global_piqa_prompted_swe_latn: exact_match
+  global_piqa_prompted_tur_latn: exact_match
+  global_piqa_prompted_ukr_cyrl: exact_match
 
 task_groups:
   open-sci-0.01:
@@ -496,6 +560,148 @@ task_groups:
         n_shots: [0]
         suite: evalchemy
         dataset: livecodebench/code_generation_lite
+
+  global-piqa-eu-completions:
+    description: "Global PIQA European languages — multiple-choice completions (0-shot, mrlbenchmarks/global-piqa-nonparallel)"
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: mrlbenchmarks/global-piqa-nonparallel
+    tasks:
+      - task: global_piqa_completions_als_latn
+        subset: als_latn
+      - task: global_piqa_completions_bos_latn
+        subset: bos_latn
+      - task: global_piqa_completions_bul_cyrl
+        subset: bul_cyrl
+      - task: global_piqa_completions_cat_latn
+        subset: cat_latn
+      - task: global_piqa_completions_ces_latn
+        subset: ces_latn
+      - task: global_piqa_completions_deu_latn
+        subset: deu_latn
+      - task: global_piqa_completions_ekk_latn
+        subset: ekk_latn
+      - task: global_piqa_completions_ell_grek
+        subset: ell_grek
+      - task: global_piqa_completions_eng_latn
+        subset: eng_latn
+      - task: global_piqa_completions_fin_latn
+        subset: fin_latn
+      - task: global_piqa_completions_fra_latn_fran
+        subset: fra_latn_fran
+      - task: global_piqa_completions_glg_latn
+        subset: glg_latn
+      - task: global_piqa_completions_hrv_latn
+        subset: hrv_latn
+      - task: global_piqa_completions_hun_latn
+        subset: hun_latn
+      - task: global_piqa_completions_isl_latn
+        subset: isl_latn
+      - task: global_piqa_completions_ita_latn
+        subset: ita_latn
+      - task: global_piqa_completions_kat_geor
+        subset: kat_geor
+      - task: global_piqa_completions_lit_latn
+        subset: lit_latn
+      - task: global_piqa_completions_mkd_cyrl
+        subset: mkd_cyrl
+      - task: global_piqa_completions_nld_latn
+        subset: nld_latn
+      - task: global_piqa_completions_nno_latn
+        subset: nno_latn
+      - task: global_piqa_completions_nob_latn
+        subset: nob_latn
+      - task: global_piqa_completions_pol_latn
+        subset: pol_latn
+      - task: global_piqa_completions_por_latn_port
+        subset: por_latn_port
+      - task: global_piqa_completions_ron_latn
+        subset: ron_latn
+      - task: global_piqa_completions_slk_latn
+        subset: slk_latn
+      - task: global_piqa_completions_slv_latn
+        subset: slv_latn
+      - task: global_piqa_completions_spa_latn_spai
+        subset: spa_latn_spai
+      - task: global_piqa_completions_srp_cyrl
+        subset: srp_cyrl
+      - task: global_piqa_completions_swe_latn
+        subset: swe_latn
+      - task: global_piqa_completions_tur_latn
+        subset: tur_latn
+      - task: global_piqa_completions_ukr_cyrl
+        subset: ukr_cyrl
+
+  global-piqa-eu-prompted:
+    description: "Global PIQA European languages — prompted generation (0-shot, mrlbenchmarks/global-piqa-nonparallel)"
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: mrlbenchmarks/global-piqa-nonparallel
+    tasks:
+      - task: global_piqa_prompted_als_latn
+        subset: als_latn
+      - task: global_piqa_prompted_bos_latn
+        subset: bos_latn
+      - task: global_piqa_prompted_bul_cyrl
+        subset: bul_cyrl
+      - task: global_piqa_prompted_cat_latn
+        subset: cat_latn
+      - task: global_piqa_prompted_ces_latn
+        subset: ces_latn
+      - task: global_piqa_prompted_deu_latn
+        subset: deu_latn
+      - task: global_piqa_prompted_ekk_latn
+        subset: ekk_latn
+      - task: global_piqa_prompted_ell_grek
+        subset: ell_grek
+      - task: global_piqa_prompted_eng_latn
+        subset: eng_latn
+      - task: global_piqa_prompted_fin_latn
+        subset: fin_latn
+      - task: global_piqa_prompted_fra_latn_fran
+        subset: fra_latn_fran
+      - task: global_piqa_prompted_glg_latn
+        subset: glg_latn
+      - task: global_piqa_prompted_hrv_latn
+        subset: hrv_latn
+      - task: global_piqa_prompted_hun_latn
+        subset: hun_latn
+      - task: global_piqa_prompted_isl_latn
+        subset: isl_latn
+      - task: global_piqa_prompted_ita_latn
+        subset: ita_latn
+      - task: global_piqa_prompted_kat_geor
+        subset: kat_geor
+      - task: global_piqa_prompted_lit_latn
+        subset: lit_latn
+      - task: global_piqa_prompted_mkd_cyrl
+        subset: mkd_cyrl
+      - task: global_piqa_prompted_nld_latn
+        subset: nld_latn
+      - task: global_piqa_prompted_nno_latn
+        subset: nno_latn
+      - task: global_piqa_prompted_nob_latn
+        subset: nob_latn
+      - task: global_piqa_prompted_pol_latn
+        subset: pol_latn
+      - task: global_piqa_prompted_por_latn_port
+        subset: por_latn_port
+      - task: global_piqa_prompted_ron_latn
+        subset: ron_latn
+      - task: global_piqa_prompted_slk_latn
+        subset: slk_latn
+      - task: global_piqa_prompted_slv_latn
+        subset: slv_latn
+      - task: global_piqa_prompted_spa_latn_spai
+        subset: spa_latn_spai
+      - task: global_piqa_prompted_srp_cyrl
+        subset: srp_cyrl
+      - task: global_piqa_prompted_swe_latn
+        subset: swe_latn
+      - task: global_piqa_prompted_tur_latn
+        subset: tur_latn
+      - task: global_piqa_prompted_ukr_cyrl
+        subset: ukr_cyrl
 
 super_groups:
   oellm-multilingual:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "oellm"
 version = "0.1.0"
 description = "OpenEuroLLM CLI"
 readme = "README.md"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.11,<3.13"
 dependencies = [
     "pandas",
     "jsonargparse",


### PR DESCRIPTION
## Add Global PIQA evaluation for 32 European languages

Adds [mrlbenchmarks/global-piqa-nonparallel](https://huggingface.co/datasets/mrlbenchmarks/global-piqa-nonparallel) as an evaluation task covering 32 European languages in two variants: **completions** (multiple-choice log-likelihood) and **prompted** (generate-until with regex extraction).

### Changes
- `oellm/resources/custom_lm_eval_tasks/global_piqa/completions/` — `_template` + 32 per-language YAMLs
- `oellm/resources/custom_lm_eval_tasks/global_piqa/prompted/` — `_template` + 32 per-language YAMLs (fixed `max_gen_toks: 256`)
- `oellm/resources/task-groups.yaml` — added `global-piqa-eu-completions` and `global-piqa-eu-prompted` task groups (64 task entries + 64 `task_metrics` entries)
- `pyproject.toml` — relaxed `requires-python` to `>=3.11,<3.13`

### Languages (32)

| Language | Code | Language | Code |
|---|---|---|---|
| Albanian | `als_latn` | Macedonian | `mkd_cyrl` |
| Bosnian | `bos_latn` | Dutch | `nld_latn` |
| Bulgarian | `bul_cyrl` | Norwegian Nynorsk | `nno_latn` |
| Catalan | `cat_latn` | Norwegian Bokmål | `nob_latn` |
| Czech | `ces_latn` | Polish | `pol_latn` |
| German | `deu_latn` | Portuguese (Portugal) | `por_latn_port` |
| Estonian | `ekk_latn` | Romanian | `ron_latn` |
| Greek | `ell_grek` | Slovak | `slk_latn` |
| English | `eng_latn` | Slovenian | `slv_latn` |
| Finnish | `fin_latn` | Spanish (Spain) | `spa_latn_spai` |
| French (France) | `fra_latn_fran` | Serbian | `srp_cyrl` |
| Galician | `glg_latn` | Swedish | `swe_latn` |
| Croatian | `hrv_latn` | Turkish | `tur_latn` |
| Hungarian | `hun_latn` | Ukrainian | `ukr_cyrl` |
| Icelandic | `isl_latn` | Italian | `ita_latn` |
| Georgian | `kat_geor` | Lithuanian | `lit_latn` |

### Baseline results — `openeurollm/datamix-9b-80-20` (0-shot, completions variant)

| Task | acc | acc_norm |
|------|-----|----------|
| Albanian (`als_latn`) | 0.64 | 0.69 |
| Bosnian (`bos_latn`) | 0.70 | 0.76 |
| Bulgarian (`bul_cyrl`) | 0.74 | 0.75 |
| Catalan (`cat_latn`) | 0.77 | 0.82 |
| Czech (`ces_latn`) | 0.74 | 0.83 |
| German (`deu_latn`) | 0.82 | 0.79 |
| Estonian (`ekk_latn`) | 0.60 | 0.61 |
| Greek (`ell_grek`) | 0.56 | 0.56 |
| English (`eng_latn`) | 0.82 | 0.79 |
| Finnish (`fin_latn`) | 0.81 | 0.80 |
| French (`fra_latn_fran`) | 0.65 | 0.71 |
| Galician (`glg_latn`) | 0.83 | 0.85 |
| Croatian (`hrv_latn`) | 0.76 | 0.76 |
| Hungarian (`hun_latn`) | 0.53 | 0.62 |
| Icelandic (`isl_latn`) | 0.58 | 0.56 |
| Italian (`ita_latn`) | 0.81 | 0.83 |
| Georgian (`kat_geor`) | 0.58 | 0.54 |
| Lithuanian (`lit_latn`) | 0.63 | 0.77 |
| Macedonian (`mkd_cyrl`) | 0.82 | 0.81 |
| Dutch (`nld_latn`) | 0.76 | 0.80 |
| Norwegian Nynorsk (`nno_latn`) | 0.71 | 0.67 |
| Norwegian Bokmål (`nob_latn`) | 0.68 | 0.70 |
| Polish (`pol_latn`) | 0.76 | 0.77 |
| Portuguese (`por_latn_port`) | 0.75 | 0.72 |
| Romanian (`ron_latn`) | 0.78 | 0.77 |
| Slovak (`slk_latn`) | 0.82 | 0.86 |
| Slovenian (`slv_latn`) | 0.65 | 0.64 |
| Spanish (`spa_latn_spai`) | 0.83 | 0.82 |
| Serbian (`srp_cyrl`) | 0.87 | 0.86 |
| Swedish (`swe_latn`) | 0.87 | 0.89 |
| Turkish (`tur_latn`) | 0.58 | 0.82 |
| Ukrainian (`ukr_cyrl`) | 0.82 | 0.85 |
| **Average** | **0.73** | **0.75** |