### PR TITLE
(re)naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A lightweight CLI for scheduling LLM evaluations across multiple HPC clusters us
 
 ## Features
 
-- **Schedule evaluations** on multiple models and tasks: `oellm-eval schedule-eval`
-- **Collect results** and check for missing evaluations: `oellm-eval collect-results`
+- **Schedule evaluations** on multiple models and tasks: `oellm-eval schedule`
+- **Collect results** and check for missing evaluations: `oellm-eval collect`
 - **Task groups** for pre-defined evaluation suites with automatic dataset pre-downloading
 - **Multi-cluster support** with auto-detection (Leonardo, LUMI, JURECA, Snellius)
 - **Automatic building and deployment of containers** 
@@ -21,12 +21,12 @@ A lightweight CLI for scheduling LLM evaluations across multiple HPC clusters us
 uv tool install -p 3.12 git+https://github.com/OpenEuroLLM/oellm-cli.git
 
 # Run evaluations using a task group (recommended)
-oellm-eval schedule-eval \
+oellm-eval schedule \
     --models "microsoft/DialoGPT-medium,EleutherAI/pythia-160m" \
     --task_groups "open-sci-0.01"
 
 # Or specify individual tasks
-oellm-eval schedule-eval \
+oellm-eval schedule \
     --models "EleutherAI/pythia-160m" \
     --tasks "hellaswag,mmlu" \
     --n_shot 5
@@ -58,13 +58,13 @@ Super groups combine multiple task groups:
 
 ```bash
 # Use a task group
-oellm-eval schedule-eval --models "model-name" --task_groups "open-sci-0.01"
+oellm-eval schedule --models "model-name" --task_groups "open-sci-0.01"
 
 # Use multiple task groups
-oellm-eval schedule-eval --models "model-name" --task_groups "belebele-eu-5-shot,global-mmlu-eu"
+oellm-eval schedule --models "model-name" --task_groups "belebele-eu-5-shot,global-mmlu-eu"
 
 # Use a super group
-oellm-eval schedule-eval --models "model-name" --task_groups "oellm-multilingual"
+oellm-eval schedule --models "model-name" --task_groups "oellm-multilingual"
 ```
 
 ## Running Locally (without SLURM)
@@ -76,7 +76,7 @@ The `--local` flag lets you run evaluations directly on your machine without a c
 uv pip install lm-eval torch transformers accelerate "datasets<4.0.0"
 
 # 2. Run evaluations locally — useful for smoke-testing with a small sample
-oellm-eval schedule-eval \
+oellm-eval schedule \
     --models "EleutherAI/pythia-160m" \
     --tasks "gsm8k" \
     --n_shot 0 \
@@ -92,7 +92,7 @@ Results are written to `./oellm-eval-output/<timestamp>/results/`.
 ```bash
 export HF_HOME=/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/hf_data
 export HF_HUB_OFFLINE=1
-oellm-eval schedule-eval ... --venv_path .venv --local true
+oellm-eval schedule ... --venv_path .venv --local true
 ```
 
 The `HF_HUB_OFFLINE` value is read when you invoke `oellm-eval` and baked into the generated script.
@@ -103,11 +103,11 @@ Override cluster defaults (partition, account, time limit, memory, etc.) with `-
 
 ```bash
 # Use a different partition (e.g. dev-g on LUMI when small-g is crowded)
-oellm-eval schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
+oellm-eval schedule --models "model-name" --task_groups "open-sci-0.01" \
   --slurm_template_var '{"PARTITION":"dev-g"}'
 
 # Multiple overrides: partition, account, time limit, GPUs, exact RAM
-oellm-eval schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
+oellm-eval schedule --models "model-name" --task_groups "open-sci-0.01" \
   --slurm_template_var '{"PARTITION":"dev-g","ACCOUNT":"myproject","TIME":"02:00:00","GPUS_PER_NODE":2,"SLURM_MEM":"96G"}'
 ```
 
@@ -123,7 +123,7 @@ override these defaults:
 
 ```bash
 # Set an explicit batch size (overrides the local/cluster default)
-BATCH_SIZE=8 oellm-eval schedule-eval \
+BATCH_SIZE=8 oellm-eval schedule \
   --models "model-name" \
   --task_groups "belebele-eu-cf" \
   --venv_path .venv
@@ -133,7 +133,7 @@ If you need full manual control over all model args, set `MODEL_ARGS`,
 for example:
 
 ```bash
-MODEL_ARGS='batch_size=8' oellm-eval schedule-eval \
+MODEL_ARGS='batch_size=8' oellm-eval schedule \
   --models "model-name" --task_groups "belebele-eu-cf" --venv_path .venv
 ```
 
@@ -151,16 +151,16 @@ After evaluations complete, collect results into a CSV:
 
 ```bash
 # Basic collection
-oellm-eval collect-results --results_dir /path/to/eval-output-dir
+oellm-eval collect --results_dir /path/to/eval-output-dir
 
 # Check for missing evaluations and create a CSV for re-running them
-oellm-eval collect-results --results_dir /path/to/eval-output-dir --check true --output_csv results.csv
+oellm-eval collect --results_dir /path/to/eval-output-dir --check true --output_csv results.csv
 ```
 
 The `--check` flag compares completed results against `jobs.csv` and outputs a `results_missing.csv` that can be used to re-schedule failed jobs:
 
 ```bash
-oellm-eval schedule-eval --eval_csv_path results_missing.csv
+oellm-eval schedule --eval_csv_path results_missing.csv
 ```
 
 ## CSV-Based Scheduling
@@ -168,7 +168,7 @@ oellm-eval schedule-eval --eval_csv_path results_missing.csv
 For full control, provide a CSV file with columns: `model_path`, `task_path`, `n_shot`, and optionally `eval_suite`:
 
 ```bash
-oellm-eval schedule-eval --eval_csv_path custom_evals.csv
+oellm-eval schedule --eval_csv_path custom_evals.csv
 ```
 
 ## Installation
@@ -201,7 +201,7 @@ We support: Leonardo, Lumi, Jureca, Jupiter, and Snellius
 ## CLI Options
 
 ```bash
-oellm-eval schedule-eval --help
+oellm-eval schedule --help
 ```
 
 ## Development
@@ -216,7 +216,7 @@ uv sync --extra dev
 uv run pytest tests/test_datasets.py -v
 
 # Download-only mode for testing
-uv run oellm-eval schedule-eval --models "EleutherAI/pythia-160m" --task_groups "open-sci-0.01" --download_only
+uv run oellm-eval schedule --models "EleutherAI/pythia-160m" --task_groups "open-sci-0.01" --download_only
 ```
 
 ## Deploying containers

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ oellm-eval schedule \
     --limit 1
 ```
 
-Results are written to `./oellm-eval-output/<timestamp>/results/`.
+Results are written to `./oellm-output/<timestamp>/results/`.
 
 **Air-gapped cluster nodes (no internet):** batch jobs set `HF_HUB_OFFLINE=1` and get `HF_HOME` from your cluster env. With `--local`, the CLI defaults `HF_HOME` to `~/.cache/huggingface` if unset and would otherwise allow Hub access—so on a compute node without network, export your real cache and offline flag before running, for example:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# OpenEuroLLM CLI (oellm)
+# OpenEuroLLM Eval (oellm-eval)
 
 A lightweight CLI for scheduling LLM evaluations across multiple HPC clusters using SLURM job arrays and Singularity containers.
 
 ## Features
 
-- **Schedule evaluations** on multiple models and tasks: `oellm schedule-eval`
-- **Collect results** and check for missing evaluations: `oellm collect-results`
+- **Schedule evaluations** on multiple models and tasks: `oellm-eval schedule-eval`
+- **Collect results** and check for missing evaluations: `oellm-eval collect-results`
 - **Task groups** for pre-defined evaluation suites with automatic dataset pre-downloading
 - **Multi-cluster support** with auto-detection (Leonardo, LUMI, JURECA, Snellius)
 - **Automatic building and deployment of containers** 
@@ -21,12 +21,12 @@ A lightweight CLI for scheduling LLM evaluations across multiple HPC clusters us
 uv tool install -p 3.12 git+https://github.com/OpenEuroLLM/oellm-cli.git
 
 # Run evaluations using a task group (recommended)
-oellm schedule-eval \
+oellm-eval schedule-eval \
     --models "microsoft/DialoGPT-medium,EleutherAI/pythia-160m" \
     --task_groups "open-sci-0.01"
 
 # Or specify individual tasks
-oellm schedule-eval \
+oellm-eval schedule-eval \
     --models "EleutherAI/pythia-160m" \
     --tasks "hellaswag,mmlu" \
     --n_shot 5
@@ -58,13 +58,13 @@ Super groups combine multiple task groups:
 
 ```bash
 # Use a task group
-oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01"
+oellm-eval schedule-eval --models "model-name" --task_groups "open-sci-0.01"
 
 # Use multiple task groups
-oellm schedule-eval --models "model-name" --task_groups "belebele-eu-5-shot,global-mmlu-eu"
+oellm-eval schedule-eval --models "model-name" --task_groups "belebele-eu-5-shot,global-mmlu-eu"
 
 # Use a super group
-oellm schedule-eval --models "model-name" --task_groups "oellm-multilingual"
+oellm-eval schedule-eval --models "model-name" --task_groups "oellm-multilingual"
 ```
 
 ## Running Locally (without SLURM)
@@ -76,7 +76,7 @@ The `--local` flag lets you run evaluations directly on your machine without a c
 uv pip install lm-eval torch transformers accelerate "datasets<4.0.0"
 
 # 2. Run evaluations locally — useful for smoke-testing with a small sample
-oellm schedule-eval \
+oellm-eval schedule-eval \
     --models "EleutherAI/pythia-160m" \
     --tasks "gsm8k" \
     --n_shot 0 \
@@ -85,17 +85,17 @@ oellm schedule-eval \
     --limit 1
 ```
 
-Results are written to `./oellm-output/<timestamp>/results/`.
+Results are written to `./oellm-eval-output/<timestamp>/results/`.
 
 **Air-gapped cluster nodes (no internet):** batch jobs set `HF_HUB_OFFLINE=1` and get `HF_HOME` from your cluster env. With `--local`, the CLI defaults `HF_HOME` to `~/.cache/huggingface` if unset and would otherwise allow Hub access—so on a compute node without network, export your real cache and offline flag before running, for example:
 
 ```bash
 export HF_HOME=/leonardo_work/OELLM_prod2026/users/shaldar0/oellm-evals/hf_data
 export HF_HUB_OFFLINE=1
-oellm schedule-eval ... --venv_path .venv --local true
+oellm-eval schedule-eval ... --venv_path .venv --local true
 ```
 
-The `HF_HUB_OFFLINE` value is read when you invoke `oellm` and baked into the generated script.
+The `HF_HUB_OFFLINE` value is read when you invoke `oellm-eval` and baked into the generated script.
 
 ## SLURM Overrides
 
@@ -103,11 +103,11 @@ Override cluster defaults (partition, account, time limit, memory, etc.) with `-
 
 ```bash
 # Use a different partition (e.g. dev-g on LUMI when small-g is crowded)
-oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
+oellm-eval schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
   --slurm_template_var '{"PARTITION":"dev-g"}'
 
 # Multiple overrides: partition, account, time limit, GPUs, exact RAM
-oellm schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
+oellm-eval schedule-eval --models "model-name" --task_groups "open-sci-0.01" \
   --slurm_template_var '{"PARTITION":"dev-g","ACCOUNT":"myproject","TIME":"02:00:00","GPUS_PER_NODE":2,"SLURM_MEM":"96G"}'
 ```
 
@@ -123,7 +123,7 @@ override these defaults:
 
 ```bash
 # Set an explicit batch size (overrides the local/cluster default)
-BATCH_SIZE=8 oellm schedule-eval \
+BATCH_SIZE=8 oellm-eval schedule-eval \
   --models "model-name" \
   --task_groups "belebele-eu-cf" \
   --venv_path .venv
@@ -133,7 +133,7 @@ If you need full manual control over all model args, set `MODEL_ARGS`,
 for example:
 
 ```bash
-MODEL_ARGS='batch_size=8' oellm schedule-eval \
+MODEL_ARGS='batch_size=8' oellm-eval schedule-eval \
   --models "model-name" --task_groups "belebele-eu-cf" --venv_path .venv
 ```
 
@@ -151,16 +151,16 @@ After evaluations complete, collect results into a CSV:
 
 ```bash
 # Basic collection
-oellm collect-results --results_dir /path/to/eval-output-dir
+oellm-eval collect-results --results_dir /path/to/eval-output-dir
 
 # Check for missing evaluations and create a CSV for re-running them
-oellm collect-results --results_dir /path/to/eval-output-dir --check true --output_csv results.csv
+oellm-eval collect-results --results_dir /path/to/eval-output-dir --check true --output_csv results.csv
 ```
 
 The `--check` flag compares completed results against `jobs.csv` and outputs a `results_missing.csv` that can be used to re-schedule failed jobs:
 
 ```bash
-oellm schedule-eval --eval_csv_path results_missing.csv
+oellm-eval schedule-eval --eval_csv_path results_missing.csv
 ```
 
 ## CSV-Based Scheduling
@@ -168,7 +168,7 @@ oellm schedule-eval --eval_csv_path results_missing.csv
 For full control, provide a CSV file with columns: `model_path`, `task_path`, `n_shot`, and optionally `eval_suite`:
 
 ```bash
-oellm schedule-eval --eval_csv_path custom_evals.csv
+oellm-eval schedule-eval --eval_csv_path custom_evals.csv
 ```
 
 ## Installation
@@ -181,7 +181,7 @@ uv tool install -p 3.12 git+https://github.com/OpenEuroLLM/oellm-cli.git
 
 Update to latest:
 ```bash
-uv tool upgrade oellm
+uv tool upgrade oellm-eval
 ```
 
 ### JURECA/JSC Specifics
@@ -201,7 +201,7 @@ We support: Leonardo, Lumi, Jureca, Jupiter, and Snellius
 ## CLI Options
 
 ```bash
-oellm schedule-eval --help
+oellm-eval schedule-eval --help
 ```
 
 ## Development
@@ -216,7 +216,7 @@ uv sync --extra dev
 uv run pytest tests/test_datasets.py -v
 
 # Download-only mode for testing
-uv run oellm schedule-eval --models "EleutherAI/pythia-160m" --task_groups "open-sci-0.01" --download_only
+uv run oellm-eval schedule-eval --models "EleutherAI/pythia-160m" --task_groups "open-sci-0.01" --download_only
 ```
 
 ## Deploying containers

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -41,7 +41,7 @@ task_groups:
 2. Use it:
 
 ```bash
-oellm-eval schedule-eval --models "model-name" --task_groups "my-benchmark"
+oellm-eval schedule --models "model-name" --task_groups "my-benchmark"
 ```
 
 ## Field Reference

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -41,7 +41,7 @@ task_groups:
 2. Use it:
 
 ```bash
-oellm schedule-eval --models "model-name" --task_groups "my-benchmark"
+oellm-eval schedule-eval --models "model-name" --task_groups "my-benchmark"
 ```
 
 ## Field Reference

--- a/docs/VENV.md
+++ b/docs/VENV.md
@@ -27,7 +27,7 @@ Instead of using pre-built containers, you can run evaluations with your own Pyt
 ## Usage
 
 ```bash
-oellm schedule-eval \
+oellm-eval schedule-eval \
     --models HuggingFaceTB/SmolLM2-135M-Instruct \
     --task_groups multilingual \
     --venv_path /path/to/.venv
@@ -47,7 +47,7 @@ uv pip install --python dclm-core-venv/bin/python -r requirements-venv-dclm.txt
 ```
 
 ```bash
-oellm schedule-eval \
+oellm-eval schedule-eval \
     --models Qwen/Qwen3-0.6B-Base \
     --task_groups dclm-core-22 \
     --venv_path dclm-core-venv \
@@ -77,7 +77,7 @@ We use [Ali's fork](https://github.com/Ali-Elganzory/evalchemy) which includes a
 3. Run with `EVALCHEMY_DIR` pointing to the cloned repo:
    ```bash
    export HF_ALLOW_CODE_EVAL=1  # required by MBPP 
-   EVALCHEMY_DIR=$(pwd)/evalchemy oellm schedule-eval \
+   EVALCHEMY_DIR=$(pwd)/evalchemy oellm-eval schedule-eval \
        --models HuggingFaceTB/SmolLM2-135M \
        --task_groups reasoning \
        --venv_path evalchemy-venv \

--- a/docs/VENV.md
+++ b/docs/VENV.md
@@ -27,7 +27,7 @@ Instead of using pre-built containers, you can run evaluations with your own Pyt
 ## Usage
 
 ```bash
-oellm-eval schedule-eval \
+oellm-eval schedule \
     --models HuggingFaceTB/SmolLM2-135M-Instruct \
     --task_groups multilingual \
     --venv_path /path/to/.venv
@@ -47,7 +47,7 @@ uv pip install --python dclm-core-venv/bin/python -r requirements-venv-dclm.txt
 ```
 
 ```bash
-oellm-eval schedule-eval \
+oellm-eval schedule \
     --models Qwen/Qwen3-0.6B-Base \
     --task_groups dclm-core-22 \
     --venv_path dclm-core-venv \
@@ -77,7 +77,7 @@ We use [Ali's fork](https://github.com/Ali-Elganzory/evalchemy) which includes a
 3. Run with `EVALCHEMY_DIR` pointing to the cloned repo:
    ```bash
    export HF_ALLOW_CODE_EVAL=1  # required by MBPP 
-   EVALCHEMY_DIR=$(pwd)/evalchemy oellm-eval schedule-eval \
+   EVALCHEMY_DIR=$(pwd)/evalchemy oellm-eval schedule \
        --models HuggingFaceTB/SmolLM2-135M \
        --task_groups reasoning \
        --venv_path evalchemy-venv \

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -169,7 +169,7 @@ def schedule_evals(
                 "--local requires --venv_path. Provide a path to a Python virtual "
                 "environment with lm_eval/lighteval installed."
             )
-        local_output = str(Path.cwd() / "oellm-output")
+        local_output = str(Path.cwd() / "oellm-eval-output")
         os.environ.setdefault("EVAL_BASE_DIR", local_output)
         os.environ.setdefault("EVAL_OUTPUT_DIR", local_output)
         os.environ.setdefault("QUEUE_LIMIT", "1")

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -169,7 +169,7 @@ def schedule_evals(
                 "--local requires --venv_path. Provide a path to a Python virtual "
                 "environment with lm_eval/lighteval installed."
             )
-        local_output = str(Path.cwd() / "oellm-eval-output")
+        local_output = str(Path.cwd() / "oellm-output")
         os.environ.setdefault("EVAL_BASE_DIR", local_output)
         os.environ.setdefault("EVAL_OUTPUT_DIR", local_output)
         os.environ.setdefault("QUEUE_LIMIT", "1")

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -843,7 +843,7 @@ def collect_results(
             missing_df.to_csv(missing_csv, index=False)
             logging.info(f"Missing jobs saved to: {missing_csv}")
             logging.info(
-                f"You can run these with: oellm schedule-eval --eval_csv_path {missing_csv}"
+                f"You can run these with: oellm-eval schedule --eval_csv_path {missing_csv}"
             )
 
             # Show some examples if verbose
@@ -861,8 +861,8 @@ def main():
     _filter_warnings()
     auto_cli(
         {
-            "schedule-eval": schedule_evals,
-            "collect-results": collect_results,
+            "schedule": schedule_evals,
+            "collect": collect_results,
         },
         as_positional=False,
         description="OELLM: Multi-cluster evaluation tool for language models",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "oellm"
+name = "oellm-eval"
 version = "0.1.0"
-description = "OpenEuroLLM CLI"
+description = "OpenEuroLLM Evaluation CLI"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
@@ -21,7 +21,7 @@ dev = [
 ]
 
 [project.scripts]
-oellm = "oellm.main:main"
+oellm-eval = "oellm.main:main"
 
 [build-system]
 requires = ["uv_build>=0.7.19,<0.8.0"]

--- a/tests/integration/test_slurm.py
+++ b/tests/integration/test_slurm.py
@@ -71,7 +71,7 @@ def run_schedule_eval(
     cmd = [
         "uv",
         "run",
-        "oellm",
+        "oellm-eval",
         "schedule-eval",
         "--models",
         "HuggingFaceTB/SmolLM2-135M-Instruct",
@@ -100,7 +100,7 @@ def run_schedule_eval_with_csv(
     cmd = [
         "uv",
         "run",
-        "oellm",
+        "oellm-eval",
         "schedule-eval",
         "--eval_csv_path",
         csv_path,

--- a/tests/integration/test_slurm.py
+++ b/tests/integration/test_slurm.py
@@ -72,7 +72,7 @@ def run_schedule_eval(
         "uv",
         "run",
         "oellm-eval",
-        "schedule-eval",
+        "schedule",
         "--models",
         "HuggingFaceTB/SmolLM2-135M-Instruct",
         "--task_groups",
@@ -101,7 +101,7 @@ def run_schedule_eval_with_csv(
         "uv",
         "run",
         "oellm-eval",
-        "schedule-eval",
+        "schedule",
         "--eval_csv_path",
         csv_path,
         "--limit",
@@ -144,7 +144,7 @@ class TestScheduleEvalDryRun:
         )
 
         assert result.returncode == 0, (
-            f"schedule-eval failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            f"schedule failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
         self.eval_dir = find_eval_dir(slurm_env)
@@ -279,10 +279,10 @@ class TestFullEvaluationPipeline:
         os.unlink(csv_path)
 
         if result.returncode != 0:
-            print(f"schedule-eval stdout:\n{result.stdout}")
-            print(f"schedule-eval stderr:\n{result.stderr}")
+            print(f"schedule stdout:\n{result.stdout}")
+            print(f"schedule stderr:\n{result.stderr}")
         assert result.returncode == 0, (
-            f"schedule-eval failed for {group_name}:\nSTDERR: {result.stderr}"
+            f"schedule failed for {group_name}:\nSTDERR: {result.stderr}"
         )
 
         print("Waiting for job to complete...")


### PR DESCRIPTION
## (Re)naming: Implementing proposed issue #61

`oellm` → `oellm-eval`, `schedule-eval` → `schedule`, `collect-results` → `collect`

The package is currently named `oellm` (installed from the `oellm-cli` repo), and the binary is also `oellm`. Neither name communicates the tool's purpose. This PR renames:

- **package** `oellm` → `oellm-eval`
- **binary entrypoint** `oellm` → `oellm-eval`
- **subcommand** `schedule-eval` → `schedule` (avoids the redundant "eval eval")
- **subcommand** `collect-results` → `collect`

The benefit is a name that expresses intent and is less confusing, especially when the tool is shared with other projects.

### Before / After

```bash
# Before
oellm schedule-eval --models "..." --task_groups "open-sci-0.01"
oellm collect-results --results_dir /path/to/output

# After
oellm-eval schedule --models "..." --task_groups "open-sci-0.01"
oellm-eval collect --results_dir /path/to/output