### PR TITLE
Refactor collect results operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,6 @@ jobs:
         run: uv sync --extra dev
 
       - name: Run tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: uv run pytest tests/ -v --ignore=tests/integration/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,11 @@ jobs:
 
       - name: Run tests
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: uv run pytest tests/ -v --ignore=tests/integration/
+          HF_TOKEN: ${{ secrets.HF_TOKEN || '' }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "HF_TOKEN not set, skipping test_datasets.py"
+            uv run pytest tests/ -v --ignore=tests/integration/ --ignore=tests/test_datasets.py
+          else
+            uv run pytest tests/ -v --ignore=tests/integration/
+          fi

--- a/README.md
+++ b/README.md
@@ -147,17 +147,32 @@ If you use custom tasks via `--tasks` that are not in the task groups registry, 
 
 ## Collecting Results
 
-After evaluations complete, collect results into a CSV:
+After evaluations complete, collect results into a CSV.  `collect-results` **recursively** searches the given directory for every `jobs.csv` file and every `.json` result file, so you can point it at a top-level output folder that contains many sub-runs:
 
-```bash
-# Basic collection
-oellm collect-results --results_dir /path/to/eval-output-dir
-
-# Check for missing evaluations and create a CSV for re-running them
-oellm collect-results --results_dir /path/to/eval-output-dir --check true --output_csv results.csv
+```
+output/
+├── hellaswag_mt1/
+│   ├── jobs.csv
+│   └── results/
+├── hellaswag_mt2/
+│   ├── jobs.csv
+│   └── results/
+└── global_mmlu1/
+    ├── jobs.csv
+    └── results/
 ```
 
-The `--check` flag compares completed results against `jobs.csv` and outputs a `results_missing.csv` that can be used to re-schedule failed jobs:
+```bash
+# Merge all results found anywhere under the directory
+oellm collect-results --results_dir /path/to/output
+
+# Check for missing evaluations and create a CSV for re-running them
+oellm collect-results --results_dir /path/to/output --check true --output_csv results.csv
+```
+
+All `jobs.csv` files found under `results_dir` are merged into one; if the same `(model_path, task_path, n_shot)` row appears in multiple files the later-sorted entry wins (override duplicates). The merged jobs list is then compared against all `.json` result files found recursively.
+
+The `--check` flag outputs a `results_missing.csv` that can be used to re-schedule failed jobs:
 
 ```bash
 oellm schedule-eval --eval_csv_path results_missing.csv

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -593,13 +593,33 @@ def collect_results(
     if not results_path.exists():
         raise ValueError(f"Results directory does not exist: {results_dir}")
 
-    # Check if we need to look in a 'results' subdirectory
-    if (results_path / "results").exists() and (results_path / "results").is_dir():
-        # User passed the top-level directory, look in results subdirectory for nested json files
+    # Discover JSON files, supporting three layouts:
+    #   1. Single run:   results_dir/results/*.json  (+ results_dir/jobs.csv)
+    #   2. Multi-run:    results_dir/*/results/*.json (+ results_dir/*/jobs.csv)
+    #   3. Flat:         results_dir/*.json
+    if (results_path / "results").is_dir():
+        # Layout 1 – single run directory
         json_files = list((results_path / "results").rglob("*.json"))
+        _jobs_csv_candidates = [results_path / "jobs.csv"]
     else:
-        # User passed the results directory directly
-        json_files = list(results_path.glob("*.json"))
+        subdir_json = [
+            f
+            for d in sorted(results_path.iterdir())
+            if d.is_dir() and (d / "results").is_dir()
+            for f in (d / "results").rglob("*.json")
+        ]
+        if subdir_json:
+            # Layout 2 – root containing multiple run subdirectories
+            json_files = subdir_json
+            _jobs_csv_candidates = sorted(
+                d / "jobs.csv"
+                for d in results_path.iterdir()
+                if d.is_dir() and (d / "jobs.csv").exists()
+            )
+        else:
+            # Layout 3 – flat directory of JSON files
+            json_files = list(results_path.glob("*.json"))
+            _jobs_csv_candidates = [results_path / "jobs.csv"]
 
     if not json_files:
         logging.warning(f"No JSON files found in {results_dir}")
@@ -610,13 +630,17 @@ def collect_results(
 
     # If check mode, also load the jobs.csv to compare
     if check:
-        jobs_csv_path = results_path / "jobs.csv"
-        if not jobs_csv_path.exists():
+        available_csvs = [p for p in _jobs_csv_candidates if p.exists()]
+        if not available_csvs:
             logging.warning(f"No jobs.csv found in {results_dir}, cannot perform check")
             check = False
         else:
-            jobs_df = pd.read_csv(jobs_csv_path)
-            logging.info(f"Found {len(jobs_df)} scheduled jobs in jobs.csv")
+            jobs_df = pd.concat(
+                [pd.read_csv(p) for p in available_csvs], ignore_index=True
+            ).drop_duplicates(subset=["model_path", "task_path", "n_shot"])
+            logging.info(
+                f"Found {len(jobs_df)} scheduled jobs across {len(available_csvs)} jobs.csv file(s)"
+            )
 
     # Collect results
     rows = []

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -716,13 +716,21 @@ def collect_results(
             if task_name.startswith("global_mmlu_") and task_name.count("_") >= 4:
                 continue
 
+            # Skip the lighteval 'all' aggregate pseudo-task
+            if task_name == "all":
+                continue
+
             # Get n_shot for this task.
             # Prefer original extraction from `n_shot_data` and `global_n_shot`,
             # and fall back to parsing a '|N' suffix in the task name.
+            # Use explicit None checks because n_shot=0 is falsy.
             task_name_clean, parsed_n = _split_task_and_nshot(task_name)
-            n_shot = (
-                n_shot_data.get(task_name_clean) or global_n_shot or parsed_n or "unknown"
-            )
+            _ns = n_shot_data.get(task_name_clean)
+            if _ns is None:
+                _ns = global_n_shot
+            if _ns is None:
+                _ns = parsed_n
+            n_shot = "unknown" if _ns is None else _ns
 
             # If this is a group aggregate and n_shot is missing, derive from any subtask
             if task_name_clean in group_aggregate_names and n_shot == "unknown":

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -523,8 +523,18 @@ def collect_results(
     """
     Collect evaluation results from JSON files and export to CSV.
 
+    Recursively searches ``results_dir`` for every sub-directory that contains
+    a ``jobs.csv`` file, merges all those CSV files into one (later directories
+    override duplicate rows), then recursively finds every ``.json`` result
+    file under ``results_dir``.
+
+    With ``--check`` the merged jobs are compared against the extracted results
+    and any missing evaluations are written to a ``*_missing.csv`` file.
+    Without ``--check`` the results are simply merged and written to
+    ``output_csv``.
+
     Args:
-        results_dir: Path to the directory containing result JSON files
+        results_dir: Root directory to search for jobs.csv files and JSON results
         output_csv: Output CSV filename (default: eval_results.csv)
         check: Check for missing evaluations and create a missing jobs CSV
         verbose: Enable verbose logging
@@ -593,30 +603,38 @@ def collect_results(
     if not results_path.exists():
         raise ValueError(f"Results directory does not exist: {results_dir}")
 
-    # Check if we need to look in a 'results' subdirectory
-    if (results_path / "results").exists() and (results_path / "results").is_dir():
-        # User passed the top-level directory, look in results subdirectory for nested json files
-        json_files = list((results_path / "results").rglob("*.json"))
+    # ------------------------------------------------------------------
+    # 1. Find all directories containing jobs.csv and merge them.
+    #    Directories are sorted so that deeper / later-alphabetical paths
+    #    are processed last, meaning their rows override earlier duplicates.
+    # ------------------------------------------------------------------
+    jobs_csv_paths = sorted(results_path.rglob("jobs.csv"))
+    if jobs_csv_paths:
+        logging.info(f"Found {len(jobs_csv_paths)} jobs.csv file(s): {[str(p) for p in jobs_csv_paths]}")
+        jobs_frames = [pd.read_csv(p) for p in jobs_csv_paths]
+        # Concatenate and let later entries win for duplicate (model_path, task_path, n_shot).
+        jobs_df = pd.concat(jobs_frames, ignore_index=True)
+        dup_cols = [c for c in ("model_path", "task_path", "n_shot") if c in jobs_df.columns]
+        if dup_cols:
+            jobs_df = jobs_df.drop_duplicates(subset=dup_cols, keep="last")
+        logging.info(f"Merged jobs.csv: {len(jobs_df)} unique jobs")
     else:
-        # User passed the results directory directly
-        json_files = list(results_path.glob("*.json"))
+        jobs_df = None
+        if check:
+            logging.warning(f"No jobs.csv found under {results_dir}, cannot perform check")
+            check = False
+
+    # ------------------------------------------------------------------
+    # 2. Recursively find all JSON result files.
+    # ------------------------------------------------------------------
+    json_files = sorted(results_path.rglob("*.json"))
 
     if not json_files:
-        logging.warning(f"No JSON files found in {results_dir}")
+        logging.warning(f"No JSON files found under {results_dir}")
         if not check:
             return
 
-    logging.info(f"Found {len(json_files)} result files")
-
-    # If check mode, also load the jobs.csv to compare
-    if check:
-        jobs_csv_path = results_path / "jobs.csv"
-        if not jobs_csv_path.exists():
-            logging.warning(f"No jobs.csv found in {results_dir}, cannot perform check")
-            check = False
-        else:
-            jobs_df = pd.read_csv(jobs_csv_path)
-            logging.info(f"Found {len(jobs_df)} scheduled jobs in jobs.csv")
+    logging.info(f"Found {len(json_files)} result file(s)")
 
     # Collect results
     rows = []

--- a/tests/test_collect_results.py
+++ b/tests/test_collect_results.py
@@ -56,7 +56,9 @@ def _lmeval_result(model_name: str, task: str, score: float, n_shot: int = 10) -
     }
 
 
-def _write_result_json(results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 10) -> None:
+def _write_result_json(
+    results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 10
+) -> None:
     results_dir.mkdir(parents=True, exist_ok=True)
     safe = model_name.replace("/", "_")
     (results_dir / f"{safe}_{task}.json").write_text(
@@ -67,6 +69,7 @@ def _write_result_json(results_dir: Path, model_name: str, task: str, score: flo
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture()
 def output_root(tmp_path: Path) -> Path:
@@ -82,34 +85,76 @@ def output_root(tmp_path: Path) -> Path:
 
     # hellaswag_mt1 --------------------------------------------------------
     mt1 = root / "hellaswag_mt1"
-    _write_jobs_csv(mt1 / "jobs.csv", [
-        {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-        {"model_path": MODEL_B, "task_path": "hellaswag_nl", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-    ])
+    _write_jobs_csv(
+        mt1 / "jobs.csv",
+        [
+            {
+                "model_path": MODEL_A,
+                "task_path": "hellaswag_da",
+                "n_shot": 10,
+                "eval_suite": "lm-eval-harness",
+            },
+            {
+                "model_path": MODEL_B,
+                "task_path": "hellaswag_nl",
+                "n_shot": 10,
+                "eval_suite": "lm-eval-harness",
+            },
+        ],
+    )
     _write_result_json(mt1 / "results", MODEL_A, "hellaswag_da", 0.63)
     _write_result_json(mt1 / "results", MODEL_B, "hellaswag_nl", 0.61)
 
     # hellaswag_mt2 --------------------------------------------------------
     mt2 = root / "hellaswag_mt2"
-    _write_jobs_csv(mt2 / "jobs.csv", [
-        {"model_path": MODEL_A, "task_path": "hellaswag_fr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-    ])
+    _write_jobs_csv(
+        mt2 / "jobs.csv",
+        [
+            {
+                "model_path": MODEL_A,
+                "task_path": "hellaswag_fr",
+                "n_shot": 10,
+                "eval_suite": "lm-eval-harness",
+            },
+        ],
+    )
     _write_result_json(mt2 / "results", MODEL_A, "hellaswag_fr", 0.59)
 
     # global_mmlu1 ---------------------------------------------------------
     mmlu1 = root / "global_mmlu1"
-    _write_jobs_csv(mmlu1 / "jobs.csv", [
-        {"model_path": MODEL_A, "task_path": "global_mmlu_full_de", "n_shot": 5, "eval_suite": "lm-eval-harness"},
-        {"model_path": MODEL_B, "task_path": "global_mmlu_full_en", "n_shot": 5, "eval_suite": "lm-eval-harness"},
-    ])
+    _write_jobs_csv(
+        mmlu1 / "jobs.csv",
+        [
+            {
+                "model_path": MODEL_A,
+                "task_path": "global_mmlu_full_de",
+                "n_shot": 5,
+                "eval_suite": "lm-eval-harness",
+            },
+            {
+                "model_path": MODEL_B,
+                "task_path": "global_mmlu_full_en",
+                "n_shot": 5,
+                "eval_suite": "lm-eval-harness",
+            },
+        ],
+    )
     _write_result_json(mmlu1 / "results", MODEL_A, "global_mmlu_full_de", 0.52, n_shot=5)
     _write_result_json(mmlu1 / "results", MODEL_B, "global_mmlu_full_en", 0.55, n_shot=5)
 
     # 2026-04-28 – has jobs.csv but no results yet -------------------------
     pending = root / "2026-04-28"
-    _write_jobs_csv(pending / "jobs.csv", [
-        {"model_path": MODEL_A, "task_path": "hellaswag_sr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-    ])
+    _write_jobs_csv(
+        pending / "jobs.csv",
+        [
+            {
+                "model_path": MODEL_A,
+                "task_path": "hellaswag_sr",
+                "n_shot": 10,
+                "eval_suite": "lm-eval-harness",
+            },
+        ],
+    )
 
     return root
 
@@ -117,6 +162,7 @@ def output_root(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestCollectResultsMerge:
     """Results are gathered from all sub-directories and merged."""
@@ -138,7 +184,13 @@ class TestCollectResultsMerge:
         collect_results(str(output_root), output_csv=out_csv)
         df = pd.read_csv(out_csv)
         tasks = set(df["task"])
-        assert tasks == {"hellaswag_da", "hellaswag_nl", "hellaswag_fr", "global_mmlu_full_de", "global_mmlu_full_en"}
+        assert tasks == {
+            "hellaswag_da",
+            "hellaswag_nl",
+            "hellaswag_fr",
+            "global_mmlu_full_de",
+            "global_mmlu_full_en",
+        }
 
     def test_correct_scores(self, output_root, tmp_path):
         out_csv = str(tmp_path / "results.csv")
@@ -164,9 +216,17 @@ class TestCollectResultsDuplicateOverride:
         # Two subdirectories both schedule the same job
         for subdir_name in ["2026-05-01", "2026-05-02"]:
             sub = root / subdir_name
-            _write_jobs_csv(sub / "jobs.csv", [
-                {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-            ])
+            _write_jobs_csv(
+                sub / "jobs.csv",
+                [
+                    {
+                        "model_path": MODEL_A,
+                        "task_path": "hellaswag_da",
+                        "n_shot": 10,
+                        "eval_suite": "lm-eval-harness",
+                    },
+                ],
+            )
 
         _write_result_json(root / "2026-05-02" / "results", MODEL_A, "hellaswag_da", 0.65)
 
@@ -176,15 +236,25 @@ class TestCollectResultsDuplicateOverride:
         # Even though two jobs.csv files declare the same job, the merged jobs
         # table should contain exactly one row for that combination.
         missing_csv = out_csv.replace(".csv", "_missing.csv")
-        assert not Path(missing_csv).exists(), "Job counted as missing despite result being present"
+        assert not Path(missing_csv).exists(), (
+            "Job counted as missing despite result being present"
+        )
 
     def test_result_duplicate_rows_not_doubled(self, tmp_path):
         """If the same JSON appears (e.g. symlink / copy), the output still has 1 row per result file."""
         root = tmp_path / "output"
         sub = root / "hellaswag_mt1"
-        _write_jobs_csv(sub / "jobs.csv", [
-            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-        ])
+        _write_jobs_csv(
+            sub / "jobs.csv",
+            [
+                {
+                    "model_path": MODEL_A,
+                    "task_path": "hellaswag_da",
+                    "n_shot": 10,
+                    "eval_suite": "lm-eval-harness",
+                },
+            ],
+        )
         _write_result_json(sub / "results", MODEL_A, "hellaswag_da", 0.63)
 
         out_csv = str(tmp_path / "results.csv")
@@ -246,9 +316,17 @@ class TestCollectResultsEdgeCases:
     def test_no_json_files_returns_without_output(self, tmp_path):
         root = tmp_path / "output"
         sub = root / "2026-04-28"
-        _write_jobs_csv(sub / "jobs.csv", [
-            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-        ])
+        _write_jobs_csv(
+            sub / "jobs.csv",
+            [
+                {
+                    "model_path": MODEL_A,
+                    "task_path": "hellaswag_da",
+                    "n_shot": 10,
+                    "eval_suite": "lm-eval-harness",
+                },
+            ],
+        )
         out_csv = str(tmp_path / "results.csv")
         collect_results(str(root), output_csv=out_csv)
         assert not Path(out_csv).exists()
@@ -261,18 +339,24 @@ class TestCollectResultsEdgeCases:
         """JSON files that use the 'groups' key (lm-eval aggregate) are handled."""
         root = tmp_path / "output"
         sub = root / "hellaswag_mt1"
-        _write_jobs_csv(sub / "jobs.csv", [
-            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
-        ])
+        _write_jobs_csv(
+            sub / "jobs.csv",
+            [
+                {
+                    "model_path": MODEL_A,
+                    "task_path": "hellaswag_da",
+                    "n_shot": 10,
+                    "eval_suite": "lm-eval-harness",
+                },
+            ],
+        )
 
         results_dir = sub / "results"
         results_dir.mkdir(parents=True)
         group_json = {
             "model_name": MODEL_A,
             "results": {},
-            "groups": {
-                "hellaswag_da": {"acc,none": 0.70, "acc_stderr,none": 0.01}
-            },
+            "groups": {"hellaswag_da": {"acc,none": 0.70, "acc_stderr,none": 0.01}},
             "group_subtasks": {"hellaswag_da": []},
             "n-shot": {"hellaswag_da": 10},
         }
@@ -315,7 +399,9 @@ def _lighteval_result(model_name: str, task: str, score: float, n_shot: int = 0)
     }
 
 
-def _write_lighteval_result(results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 0) -> None:
+def _write_lighteval_result(
+    results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 0
+) -> None:
     results_dir.mkdir(parents=True, exist_ok=True)
     safe = model_name.replace("/", "_") + "_" + task.replace(":", "_")
     (results_dir / f"{safe}.json").write_text(
@@ -329,11 +415,29 @@ def xcopa_root(tmp_path: Path) -> Path:
     root = tmp_path / "output"
     sub = root / "2026-05-19-xcopa"
 
-    _write_jobs_csv(sub / "jobs.csv", [
-        {"model_path": MODEL_HUB, "task_path": "xcopa:et", "n_shot": 0, "eval_suite": "lighteval"},
-        {"model_path": MODEL_HUB, "task_path": "xcopa:it", "n_shot": 0, "eval_suite": "lighteval"},
-        {"model_path": MODEL_HUB, "task_path": "xcopa:tr", "n_shot": 0, "eval_suite": "lighteval"},
-    ])
+    _write_jobs_csv(
+        sub / "jobs.csv",
+        [
+            {
+                "model_path": MODEL_HUB,
+                "task_path": "xcopa:et",
+                "n_shot": 0,
+                "eval_suite": "lighteval",
+            },
+            {
+                "model_path": MODEL_HUB,
+                "task_path": "xcopa:it",
+                "n_shot": 0,
+                "eval_suite": "lighteval",
+            },
+            {
+                "model_path": MODEL_HUB,
+                "task_path": "xcopa:tr",
+                "n_shot": 0,
+                "eval_suite": "lighteval",
+            },
+        ],
+    )
     results_dir = sub / "results"
     _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:et", 0.614)
     _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:it", 0.660)
@@ -391,17 +495,37 @@ class TestCollectResultsLighteval:
         out_csv = str(tmp_path / "results.csv")
         collect_results(str(xcopa_root), output_csv=out_csv, check=True)
         missing_csv = out_csv.replace(".csv", "_missing.csv")
-        assert not Path(missing_csv).exists(), "All jobs completed but missing CSV was created"
+        assert not Path(missing_csv).exists(), (
+            "All jobs completed but missing CSV was created"
+        )
 
     def test_check_mode_partial_missing(self, tmp_path):
         """When one xcopa task result is absent it appears in missing CSV."""
         root = tmp_path / "output"
         sub = root / "2026-05-19-xcopa"
-        _write_jobs_csv(sub / "jobs.csv", [
-            {"model_path": MODEL_HUB, "task_path": "xcopa:et", "n_shot": 0, "eval_suite": "lighteval"},
-            {"model_path": MODEL_HUB, "task_path": "xcopa:it", "n_shot": 0, "eval_suite": "lighteval"},
-            {"model_path": MODEL_HUB, "task_path": "xcopa:tr", "n_shot": 0, "eval_suite": "lighteval"},
-        ])
+        _write_jobs_csv(
+            sub / "jobs.csv",
+            [
+                {
+                    "model_path": MODEL_HUB,
+                    "task_path": "xcopa:et",
+                    "n_shot": 0,
+                    "eval_suite": "lighteval",
+                },
+                {
+                    "model_path": MODEL_HUB,
+                    "task_path": "xcopa:it",
+                    "n_shot": 0,
+                    "eval_suite": "lighteval",
+                },
+                {
+                    "model_path": MODEL_HUB,
+                    "task_path": "xcopa:tr",
+                    "n_shot": 0,
+                    "eval_suite": "lighteval",
+                },
+            ],
+        )
         results_dir = sub / "results"
         # Only write two of the three results
         _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:et", 0.614)

--- a/tests/test_collect_results.py
+++ b/tests/test_collect_results.py
@@ -1,0 +1,415 @@
+"""Tests for collect_results – mirrors the output/ folder layout used in practice.
+
+Typical on-disk structure that these tests reproduce:
+
+    output_root/
+        hellaswag_mt1/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        hellaswag_mt2/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        global_mmlu1/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        2026-04-28-no-results/
+            jobs.csv            ← jobs.csv present but no results dir yet
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from oellm.main import collect_results
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MODEL_A = "/cache/hub/model-a/snapshots/aaa"
+MODEL_B = "/cache/hub/model-b/snapshots/bbb"
+
+
+def _write_jobs_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def _lmeval_result(model_name: str, task: str, score: float, n_shot: int = 10) -> dict:
+    """Minimal lm-eval result JSON matching the real schema."""
+    return {
+        "model_name": model_name,
+        "results": {
+            task: {
+                "alias": task,
+                "acc,none": score,
+                "acc_stderr,none": 0.005,
+            }
+        },
+        "group_subtasks": {task: []},
+        "n-shot": {task: n_shot},
+    }
+
+
+def _write_result_json(results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 10) -> None:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    safe = model_name.replace("/", "_")
+    (results_dir / f"{safe}_{task}.json").write_text(
+        json.dumps(_lmeval_result(model_name, task, score, n_shot))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def output_root(tmp_path: Path) -> Path:
+    """
+    Builds a directory tree that mirrors the real output/ folder:
+
+        hellaswag_mt1/  – 2 models × 1 task each, both results present
+        hellaswag_mt2/  – 1 model × 1 task, result present
+        global_mmlu1/   – 1 model × 1 task, result present
+        2026-04-28/     – jobs.csv only, no results directory yet
+    """
+    root = tmp_path / "output"
+
+    # hellaswag_mt1 --------------------------------------------------------
+    mt1 = root / "hellaswag_mt1"
+    _write_jobs_csv(mt1 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        {"model_path": MODEL_B, "task_path": "hellaswag_nl", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mt1 / "results", MODEL_A, "hellaswag_da", 0.63)
+    _write_result_json(mt1 / "results", MODEL_B, "hellaswag_nl", 0.61)
+
+    # hellaswag_mt2 --------------------------------------------------------
+    mt2 = root / "hellaswag_mt2"
+    _write_jobs_csv(mt2 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_fr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mt2 / "results", MODEL_A, "hellaswag_fr", 0.59)
+
+    # global_mmlu1 ---------------------------------------------------------
+    mmlu1 = root / "global_mmlu1"
+    _write_jobs_csv(mmlu1 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "global_mmlu_full_de", "n_shot": 5, "eval_suite": "lm-eval-harness"},
+        {"model_path": MODEL_B, "task_path": "global_mmlu_full_en", "n_shot": 5, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mmlu1 / "results", MODEL_A, "global_mmlu_full_de", 0.52, n_shot=5)
+    _write_result_json(mmlu1 / "results", MODEL_B, "global_mmlu_full_en", 0.55, n_shot=5)
+
+    # 2026-04-28 – has jobs.csv but no results yet -------------------------
+    pending = root / "2026-04-28"
+    _write_jobs_csv(pending / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_sr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCollectResultsMerge:
+    """Results are gathered from all sub-directories and merged."""
+
+    def test_output_csv_created(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        assert Path(out_csv).exists()
+
+    def test_all_results_present(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        # 5 result JSONs were written across all subdirs
+        assert len(df) == 5
+
+    def test_correct_tasks_extracted(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        tasks = set(df["task"])
+        assert tasks == {"hellaswag_da", "hellaswag_nl", "hellaswag_fr", "global_mmlu_full_de", "global_mmlu_full_en"}
+
+    def test_correct_scores(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        row = df[df["task"] == "hellaswag_da"].iloc[0]
+        assert abs(row["performance"] - 0.63) < 1e-6
+
+    def test_n_shot_preserved(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert set(df[df["task"] == "global_mmlu_full_de"]["n_shot"]) == {5}
+
+
+class TestCollectResultsDuplicateOverride:
+    """When the same (model_path, task_path, n_shot) row appears in multiple
+    jobs.csv files the last-sorted entry wins."""
+
+    def test_duplicate_jobs_deduplicated(self, tmp_path):
+        root = tmp_path / "output"
+
+        # Two subdirectories both schedule the same job
+        for subdir_name in ["2026-05-01", "2026-05-02"]:
+            sub = root / subdir_name
+            _write_jobs_csv(sub / "jobs.csv", [
+                {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+            ])
+
+        _write_result_json(root / "2026-05-02" / "results", MODEL_A, "hellaswag_da", 0.65)
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv, check=True)
+
+        # Even though two jobs.csv files declare the same job, the merged jobs
+        # table should contain exactly one row for that combination.
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists(), "Job counted as missing despite result being present"
+
+    def test_result_duplicate_rows_not_doubled(self, tmp_path):
+        """If the same JSON appears (e.g. symlink / copy), the output still has 1 row per result file."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+        _write_result_json(sub / "results", MODEL_A, "hellaswag_da", 0.63)
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert len(df) == 1
+
+
+class TestCollectResultsCheckMode:
+    """--check compares merged results against merged jobs and writes _missing.csv."""
+
+    def test_all_complete_no_missing_csv(self, output_root, tmp_path):
+        """All jobs in `output_root` except the pending dir have results already."""
+        # The fixture has hellaswag_sr scheduled but no result JSON
+        # Remove the pending jobs.csv to get a fully-complete run
+        (output_root / "2026-04-28" / "jobs.csv").unlink()
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists()
+
+    def test_missing_jobs_written_to_csv(self, output_root, tmp_path):
+        """hellaswag_sr is in jobs.csv but has no result JSON → appears in missing CSV."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert Path(missing_csv).exists()
+        missing_df = pd.read_csv(missing_csv)
+        assert len(missing_df) >= 1
+        assert "hellaswag_sr" in missing_df["task_path"].values
+
+    def test_missing_csv_columns(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        missing_df = pd.read_csv(missing_csv)
+        for col in ("model_path", "task_path", "n_shot"):
+            assert col in missing_df.columns
+
+    def test_check_without_any_jobs_csv(self, tmp_path):
+        """If no jobs.csv exists anywhere, check mode is silently disabled."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_result_json(sub / "results", MODEL_A, "hellaswag_da", 0.63)
+
+        out_csv = str(tmp_path / "results.csv")
+        # Should not raise even though check=True and no jobs.csv exists
+        collect_results(str(root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists()
+
+
+class TestCollectResultsEdgeCases:
+    def test_no_json_files_returns_without_output(self, tmp_path):
+        root = tmp_path / "output"
+        sub = root / "2026-04-28"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        assert not Path(out_csv).exists()
+
+    def test_nonexistent_results_dir_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            collect_results(str(tmp_path / "nonexistent"))
+
+    def test_groups_json_extracted(self, tmp_path):
+        """JSON files that use the 'groups' key (lm-eval aggregate) are handled."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+
+        results_dir = sub / "results"
+        results_dir.mkdir(parents=True)
+        group_json = {
+            "model_name": MODEL_A,
+            "results": {},
+            "groups": {
+                "hellaswag_da": {"acc,none": 0.70, "acc_stderr,none": 0.01}
+            },
+            "group_subtasks": {"hellaswag_da": []},
+            "n-shot": {"hellaswag_da": 10},
+        }
+        (results_dir / "group_result.json").write_text(json.dumps(group_json))
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert len(df) == 1
+        assert abs(df.iloc[0]["performance"] - 0.70) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Lighteval (xcopa-eu style) helpers and tests
+# ---------------------------------------------------------------------------
+
+MODEL_HUB = "openeurollm/datamix-9b-80-20"
+
+
+def _lighteval_result(model_name: str, task: str, score: float, n_shot: int = 0) -> dict:
+    """Minimal lighteval result JSON.
+
+    Lighteval stores task names with a ``|n_shot`` suffix in the results dict
+    and does *not* include a top-level ``n-shot`` key.  It also adds an ``all``
+    aggregate entry that must not be treated as an independent task.
+    """
+    task_key = f"{task}|{n_shot}"
+    return {
+        "config_general": {
+            "model_name": model_name,
+        },
+        "results": {
+            task_key: {"acc": score, "acc_stderr": 0.02},
+            "all": {"acc": score, "acc_stderr": 0.02},
+        },
+        "versions": {},
+        "config_tasks": {},
+        "summary_tasks": {},
+        "summary_general": {},
+    }
+
+
+def _write_lighteval_result(results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 0) -> None:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    safe = model_name.replace("/", "_") + "_" + task.replace(":", "_")
+    (results_dir / f"{safe}.json").write_text(
+        json.dumps(_lighteval_result(model_name, task, score, n_shot))
+    )
+
+
+@pytest.fixture()
+def xcopa_root(tmp_path: Path) -> Path:
+    """Mirrors the real xcopa-eu eval output directory structure."""
+    root = tmp_path / "output"
+    sub = root / "2026-05-19-xcopa"
+
+    _write_jobs_csv(sub / "jobs.csv", [
+        {"model_path": MODEL_HUB, "task_path": "xcopa:et", "n_shot": 0, "eval_suite": "lighteval"},
+        {"model_path": MODEL_HUB, "task_path": "xcopa:it", "n_shot": 0, "eval_suite": "lighteval"},
+        {"model_path": MODEL_HUB, "task_path": "xcopa:tr", "n_shot": 0, "eval_suite": "lighteval"},
+    ])
+    results_dir = sub / "results"
+    _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:et", 0.614)
+    _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:it", 0.660)
+    _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:tr", 0.666)
+
+    return root
+
+
+class TestCollectResultsLighteval:
+    """collect-results must correctly parse lighteval JSON output."""
+
+    def test_extracts_three_tasks(self, xcopa_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(xcopa_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert len(df) == 3, f"Expected 3 rows, got {len(df)}: {df['task'].tolist()}"
+
+    def test_correct_task_names_extracted(self, xcopa_root, tmp_path):
+        """Task names should not include the |n_shot suffix."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(xcopa_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert set(df["task"]) == {"xcopa:et", "xcopa:it", "xcopa:tr"}
+
+    def test_all_aggregate_not_extracted(self, xcopa_root, tmp_path):
+        """The lighteval 'all' pseudo-task must not appear in the output."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(xcopa_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert "all" not in df["task"].values
+
+    def test_n_shot_zero_preserved(self, xcopa_root, tmp_path):
+        """n_shot=0 is a valid value and must not be coerced to 'unknown'."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(xcopa_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert set(df["n_shot"]) == {0}
+
+    def test_correct_scores(self, xcopa_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(xcopa_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        row = df[df["task"] == "xcopa:tr"].iloc[0]
+        assert abs(row["performance"] - 0.666) < 1e-6
+
+    def test_model_name_from_config_general(self, xcopa_root, tmp_path):
+        """Model name must be read from config_general.model_name in lighteval JSONs."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(xcopa_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert set(df["model_name"]) == {MODEL_HUB}
+
+    def test_check_mode_all_completed(self, xcopa_root, tmp_path):
+        """All 3 xcopa jobs have results; check mode must report 0 missing."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(xcopa_root), output_csv=out_csv, check=True)
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists(), "All jobs completed but missing CSV was created"
+
+    def test_check_mode_partial_missing(self, tmp_path):
+        """When one xcopa task result is absent it appears in missing CSV."""
+        root = tmp_path / "output"
+        sub = root / "2026-05-19-xcopa"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_HUB, "task_path": "xcopa:et", "n_shot": 0, "eval_suite": "lighteval"},
+            {"model_path": MODEL_HUB, "task_path": "xcopa:it", "n_shot": 0, "eval_suite": "lighteval"},
+            {"model_path": MODEL_HUB, "task_path": "xcopa:tr", "n_shot": 0, "eval_suite": "lighteval"},
+        ])
+        results_dir = sub / "results"
+        # Only write two of the three results
+        _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:et", 0.614)
+        _write_lighteval_result(results_dir, MODEL_HUB, "xcopa:it", 0.660)
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv, check=True)
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert Path(missing_csv).exists()
+        missing_df = pd.read_csv(missing_csv)
+        assert list(missing_df["task_path"]) == ["xcopa:tr"]

--- a/tests/test_collect_results.py
+++ b/tests/test_collect_results.py
@@ -1,0 +1,285 @@
+"""Tests for collect_results – mirrors the output/ folder layout used in practice.
+
+Typical on-disk structure that these tests reproduce:
+
+    output_root/
+        hellaswag_mt1/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        hellaswag_mt2/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        global_mmlu1/
+            jobs.csv
+            results/
+                <hash>_<timestamp>.json
+        2026-04-28-no-results/
+            jobs.csv            ← jobs.csv present but no results dir yet
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from oellm.main import collect_results
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MODEL_A = "/cache/hub/model-a/snapshots/aaa"
+MODEL_B = "/cache/hub/model-b/snapshots/bbb"
+
+
+def _write_jobs_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def _lmeval_result(model_name: str, task: str, score: float, n_shot: int = 10) -> dict:
+    """Minimal lm-eval result JSON matching the real schema."""
+    return {
+        "model_name": model_name,
+        "results": {
+            task: {
+                "alias": task,
+                "acc,none": score,
+                "acc_stderr,none": 0.005,
+            }
+        },
+        "group_subtasks": {task: []},
+        "n-shot": {task: n_shot},
+    }
+
+
+def _write_result_json(results_dir: Path, model_name: str, task: str, score: float, n_shot: int = 10) -> None:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    safe = model_name.replace("/", "_")
+    (results_dir / f"{safe}_{task}.json").write_text(
+        json.dumps(_lmeval_result(model_name, task, score, n_shot))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def output_root(tmp_path: Path) -> Path:
+    """
+    Builds a directory tree that mirrors the real output/ folder:
+
+        hellaswag_mt1/  – 2 models × 1 task each, both results present
+        hellaswag_mt2/  – 1 model × 1 task, result present
+        global_mmlu1/   – 1 model × 1 task, result present
+        2026-04-28/     – jobs.csv only, no results directory yet
+    """
+    root = tmp_path / "output"
+
+    # hellaswag_mt1 --------------------------------------------------------
+    mt1 = root / "hellaswag_mt1"
+    _write_jobs_csv(mt1 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        {"model_path": MODEL_B, "task_path": "hellaswag_nl", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mt1 / "results", MODEL_A, "hellaswag_da", 0.63)
+    _write_result_json(mt1 / "results", MODEL_B, "hellaswag_nl", 0.61)
+
+    # hellaswag_mt2 --------------------------------------------------------
+    mt2 = root / "hellaswag_mt2"
+    _write_jobs_csv(mt2 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_fr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mt2 / "results", MODEL_A, "hellaswag_fr", 0.59)
+
+    # global_mmlu1 ---------------------------------------------------------
+    mmlu1 = root / "global_mmlu1"
+    _write_jobs_csv(mmlu1 / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "global_mmlu_full_de", "n_shot": 5, "eval_suite": "lm-eval-harness"},
+        {"model_path": MODEL_B, "task_path": "global_mmlu_full_en", "n_shot": 5, "eval_suite": "lm-eval-harness"},
+    ])
+    _write_result_json(mmlu1 / "results", MODEL_A, "global_mmlu_full_de", 0.52, n_shot=5)
+    _write_result_json(mmlu1 / "results", MODEL_B, "global_mmlu_full_en", 0.55, n_shot=5)
+
+    # 2026-04-28 – has jobs.csv but no results yet -------------------------
+    pending = root / "2026-04-28"
+    _write_jobs_csv(pending / "jobs.csv", [
+        {"model_path": MODEL_A, "task_path": "hellaswag_sr", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+    ])
+
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCollectResultsMerge:
+    """Results are gathered from all sub-directories and merged."""
+
+    def test_output_csv_created(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        assert Path(out_csv).exists()
+
+    def test_all_results_present(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        # 5 result JSONs were written across all subdirs
+        assert len(df) == 5
+
+    def test_correct_tasks_extracted(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        tasks = set(df["task"])
+        assert tasks == {"hellaswag_da", "hellaswag_nl", "hellaswag_fr", "global_mmlu_full_de", "global_mmlu_full_en"}
+
+    def test_correct_scores(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        row = df[df["task"] == "hellaswag_da"].iloc[0]
+        assert abs(row["performance"] - 0.63) < 1e-6
+
+    def test_n_shot_preserved(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert set(df[df["task"] == "global_mmlu_full_de"]["n_shot"]) == {5}
+
+
+class TestCollectResultsDuplicateOverride:
+    """When the same (model_path, task_path, n_shot) row appears in multiple
+    jobs.csv files the last-sorted entry wins."""
+
+    def test_duplicate_jobs_deduplicated(self, tmp_path):
+        root = tmp_path / "output"
+
+        # Two subdirectories both schedule the same job
+        for subdir_name in ["2026-05-01", "2026-05-02"]:
+            sub = root / subdir_name
+            _write_jobs_csv(sub / "jobs.csv", [
+                {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+            ])
+
+        _write_result_json(root / "2026-05-02" / "results", MODEL_A, "hellaswag_da", 0.65)
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv, check=True)
+
+        # Even though two jobs.csv files declare the same job, the merged jobs
+        # table should contain exactly one row for that combination.
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists(), "Job counted as missing despite result being present"
+
+    def test_result_duplicate_rows_not_doubled(self, tmp_path):
+        """If the same JSON appears (e.g. symlink / copy), the output still has 1 row per result file."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+        _write_result_json(sub / "results", MODEL_A, "hellaswag_da", 0.63)
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert len(df) == 1
+
+
+class TestCollectResultsCheckMode:
+    """--check compares merged results against merged jobs and writes _missing.csv."""
+
+    def test_all_complete_no_missing_csv(self, output_root, tmp_path):
+        """All jobs in `output_root` except the pending dir have results already."""
+        # The fixture has hellaswag_sr scheduled but no result JSON
+        # Remove the pending jobs.csv to get a fully-complete run
+        (output_root / "2026-04-28" / "jobs.csv").unlink()
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists()
+
+    def test_missing_jobs_written_to_csv(self, output_root, tmp_path):
+        """hellaswag_sr is in jobs.csv but has no result JSON → appears in missing CSV."""
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert Path(missing_csv).exists()
+        missing_df = pd.read_csv(missing_csv)
+        assert len(missing_df) >= 1
+        assert "hellaswag_sr" in missing_df["task_path"].values
+
+    def test_missing_csv_columns(self, output_root, tmp_path):
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(output_root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        missing_df = pd.read_csv(missing_csv)
+        for col in ("model_path", "task_path", "n_shot"):
+            assert col in missing_df.columns
+
+    def test_check_without_any_jobs_csv(self, tmp_path):
+        """If no jobs.csv exists anywhere, check mode is silently disabled."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_result_json(sub / "results", MODEL_A, "hellaswag_da", 0.63)
+
+        out_csv = str(tmp_path / "results.csv")
+        # Should not raise even though check=True and no jobs.csv exists
+        collect_results(str(root), output_csv=out_csv, check=True)
+
+        missing_csv = out_csv.replace(".csv", "_missing.csv")
+        assert not Path(missing_csv).exists()
+
+
+class TestCollectResultsEdgeCases:
+    def test_no_json_files_returns_without_output(self, tmp_path):
+        root = tmp_path / "output"
+        sub = root / "2026-04-28"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        assert not Path(out_csv).exists()
+
+    def test_nonexistent_results_dir_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            collect_results(str(tmp_path / "nonexistent"))
+
+    def test_groups_json_extracted(self, tmp_path):
+        """JSON files that use the 'groups' key (lm-eval aggregate) are handled."""
+        root = tmp_path / "output"
+        sub = root / "hellaswag_mt1"
+        _write_jobs_csv(sub / "jobs.csv", [
+            {"model_path": MODEL_A, "task_path": "hellaswag_da", "n_shot": 10, "eval_suite": "lm-eval-harness"},
+        ])
+
+        results_dir = sub / "results"
+        results_dir.mkdir(parents=True)
+        group_json = {
+            "model_name": MODEL_A,
+            "results": {},
+            "groups": {
+                "hellaswag_da": {"acc,none": 0.70, "acc_stderr,none": 0.01}
+            },
+            "group_subtasks": {"hellaswag_da": []},
+            "n-shot": {"hellaswag_da": 10},
+        }
+        (results_dir / "group_result.json").write_text(json.dumps(group_json))
+
+        out_csv = str(tmp_path / "results.csv")
+        collect_results(str(root), output_csv=out_csv)
+        df = pd.read_csv(out_csv)
+        assert len(df) == 1
+        assert abs(df.iloc[0]["performance"] - 0.70) < 1e-6


### PR DESCRIPTION
## Changes

### Note
This PR was two separate PRs (#64, #67) fixed some issues and submitting as one.

### `oellm/main.py`
- **Multi-directory support**: `collect-results` now recursively discovers all `jobs.csv` and result JSON files under the given root directory, supporting the real `oellm-output/<timestamp>/` folder structure
- **Duplicate deduplication**: when multiple `jobs.csv` files schedule the same job, later entries win
- **Lighteval fixes**:
  - `n_shot=0` is now correctly preserved (was coerced to `"unknown"` due to falsy check)
  - The lighteval `all` aggregate pseudo-task is skipped

### `tests/test_collect_results.py` *(new)*
- Full test suite covering: multi-dir merge, duplicate override, check mode (missing jobs), edge cases, and lighteval-specific output parsing

### `.github/workflows/ci.yml`
- Pass `HF_TOKEN` secret to test step to avoid HF rate limiting
- Skip `test_datasets.py` gracefully when `HF_TOKEN` is not configured