### PR TITLE
task-groups template expansion

### DIFF
--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -176,79 +176,14 @@ task_groups:
     suite: lm-eval-harness
     n_shots: [0]
     dataset: Davlan/sib200
+    valid_langs: [bul_Cyrl, hrv_Latn, ces_Latn, dan_Latn, nld_Latn, eng_Latn, est_Latn, fin_Latn,
+                  fra_Latn, deu_Latn, ell_Grek, hun_Latn, gle_Latn, ita_Latn, lvs_Latn, lit_Latn,
+                  mlt_Latn, pol_Latn, por_Latn, ron_Latn, slk_Latn, slv_Latn, spa_Latn, swe_Latn,
+                  cat_Latn, eus_Latn, glg_Latn, bos_Latn, kat_Geor, mkd_Cyrl, als_Latn, srp_Cyrl,
+                  tur_Latn, ukr_Cyrl, isl_Latn, nob_Latn]
     tasks:
-      - task: sib200_bul_Cyrl
-        subset: bul_Cyrl
-      - task: sib200_hrv_Latn
-        subset: hrv_Latn
-      - task: sib200_ces_Latn
-        subset: ces_Latn
-      - task: sib200_dan_Latn
-        subset: dan_Latn
-      - task: sib200_nld_Latn
-        subset: nld_Latn
-      - task: sib200_eng_Latn
-        subset: eng_Latn
-      - task: sib200_est_Latn
-        subset: est_Latn
-      - task: sib200_fin_Latn
-        subset: fin_Latn
-      - task: sib200_fra_Latn
-        subset: fra_Latn
-      - task: sib200_deu_Latn
-        subset: deu_Latn
-      - task: sib200_ell_Grek
-        subset: ell_Grek
-      - task: sib200_hun_Latn
-        subset: hun_Latn
-      - task: sib200_gle_Latn
-        subset: gle_Latn
-      - task: sib200_ita_Latn
-        subset: ita_Latn
-      - task: sib200_lvs_Latn
-        subset: lvs_Latn
-      - task: sib200_lit_Latn
-        subset: lit_Latn
-      - task: sib200_mlt_Latn
-        subset: mlt_Latn
-      - task: sib200_pol_Latn
-        subset: pol_Latn
-      - task: sib200_por_Latn
-        subset: por_Latn
-      - task: sib200_ron_Latn
-        subset: ron_Latn
-      - task: sib200_slk_Latn
-        subset: slk_Latn
-      - task: sib200_slv_Latn
-        subset: slv_Latn
-      - task: sib200_spa_Latn
-        subset: spa_Latn
-      - task: sib200_swe_Latn
-        subset: swe_Latn
-      - task: sib200_cat_Latn
-        subset: cat_Latn
-      - task: sib200_eus_Latn
-        subset: eus_Latn
-      - task: sib200_glg_Latn
-        subset: glg_Latn
-      - task: sib200_bos_Latn
-        subset: bos_Latn
-      - task: sib200_kat_Geor
-        subset: kat_Geor
-      - task: sib200_mkd_Cyrl
-        subset: mkd_Cyrl
-      - task: sib200_als_Latn
-        subset: als_Latn
-      - task: sib200_srp_Cyrl
-        subset: srp_Cyrl
-      - task: sib200_tur_Latn
-        subset: tur_Latn
-      - task: sib200_ukr_Cyrl
-        subset: ukr_Cyrl
-      - task: sib200_isl_Latn
-        subset: isl_Latn
-      - task: sib200_nob_Latn
-        subset: nob_Latn
+      - task: "sib200_{lang}"
+        subset: "{lang}"
   open-sci-0.01:
     description: "open-sci-ref 0.01 evals"
     suite: lm-eval-harness
@@ -299,214 +234,54 @@ task_groups:
     suite: lm-eval-harness
     n_shots: [5]
     dataset: facebook/belebele
+    valid_langs: [bul_Cyrl, hrv_Latn, ces_Latn, dan_Latn, nld_Latn, eng_Latn, est_Latn, fin_Latn,
+                  fra_Latn, deu_Latn, ell_Grek, hun_Latn, ita_Latn, lvs_Latn, lit_Latn, mlt_Latn,
+                  pol_Latn, por_Latn, ron_Latn, slk_Latn, slv_Latn, spa_Latn, swe_Latn, nob_Latn]
     tasks:
-      - task: belebele_bul_Cyrl
-        subset: bul_Cyrl
-      - task: belebele_hrv_Latn
-        subset: hrv_Latn
-      - task: belebele_ces_Latn
-        subset: ces_Latn
-      - task: belebele_dan_Latn
-        subset: dan_Latn
-      - task: belebele_nld_Latn
-        subset: nld_Latn
-      - task: belebele_eng_Latn
-        subset: eng_Latn
-      - task: belebele_est_Latn
-        subset: est_Latn
-      - task: belebele_fin_Latn
-        subset: fin_Latn
-      - task: belebele_fra_Latn
-        subset: fra_Latn
-      - task: belebele_deu_Latn
-        subset: deu_Latn
-      - task: belebele_ell_Grek
-        subset: ell_Grek
-      - task: belebele_hun_Latn
-        subset: hun_Latn
-      - task: belebele_ita_Latn
-        subset: ita_Latn
-      - task: belebele_lvs_Latn
-        subset: lvs_Latn
-      - task: belebele_lit_Latn
-        subset: lit_Latn
-      - task: belebele_mlt_Latn
-        subset: mlt_Latn
-      - task: belebele_pol_Latn
-        subset: pol_Latn
-      - task: belebele_por_Latn
-        subset: por_Latn
-      - task: belebele_ron_Latn
-        subset: ron_Latn
-      - task: belebele_slk_Latn
-        subset: slk_Latn
-      - task: belebele_slv_Latn
-        subset: slv_Latn
-      - task: belebele_spa_Latn
-        subset: spa_Latn
-      - task: belebele_swe_Latn
-        subset: swe_Latn
-      - task: belebele_nob_Latn
-        subset: nob_Latn
+      - task: "belebele_{lang}"
+        subset: "{lang}"
   belebele-eu-cf:
     description: "Belebele European language tasks (cloze formulation, lighteval)"
     suite: lighteval
     n_shots: [0]
     dataset: facebook/belebele
+    valid_langs: [bul_Cyrl, hrv_Latn, ces_Latn, dan_Latn, nld_Latn, eng_Latn, est_Latn, fin_Latn,
+                  fra_Latn, deu_Latn, ell_Grek, hun_Latn, ita_Latn, lvs_Latn, lit_Latn, mlt_Latn,
+                  pol_Latn, por_Latn, ron_Latn, slk_Latn, slv_Latn, spa_Latn, swe_Latn, nob_Latn,
+                  eus_Latn, cat_Latn]
     tasks:
-      - task: belebele_bul_Cyrl_cf
-        subset: bul_Cyrl
-      - task: belebele_hrv_Latn_cf
-        subset: hrv_Latn
-      - task: belebele_ces_Latn_cf
-        subset: ces_Latn
-      - task: belebele_dan_Latn_cf
-        subset: dan_Latn
-      - task: belebele_nld_Latn_cf
-        subset: nld_Latn
-      - task: belebele_eng_Latn_cf
-        subset: eng_Latn
-      - task: belebele_est_Latn_cf
-        subset: est_Latn
-      - task: belebele_fin_Latn_cf
-        subset: fin_Latn
-      - task: belebele_fra_Latn_cf
-        subset: fra_Latn
-      - task: belebele_deu_Latn_cf
-        subset: deu_Latn
-      - task: belebele_ell_Grek_cf
-        subset: ell_Grek
-      - task: belebele_hun_Latn_cf
-        subset: hun_Latn
-      - task: belebele_ita_Latn_cf
-        subset: ita_Latn
-      - task: belebele_lvs_Latn_cf
-        subset: lvs_Latn
-      - task: belebele_lit_Latn_cf
-        subset: lit_Latn
-      - task: belebele_mlt_Latn_cf
-        subset: mlt_Latn
-      - task: belebele_pol_Latn_cf
-        subset: pol_Latn
-      - task: belebele_por_Latn_cf
-        subset: por_Latn
-      - task: belebele_ron_Latn_cf
-        subset: ron_Latn
-      - task: belebele_slk_Latn_cf
-        subset: slk_Latn
-      - task: belebele_slv_Latn_cf
-        subset: slv_Latn
-      - task: belebele_spa_Latn_cf
-        subset: spa_Latn
-      - task: belebele_swe_Latn_cf
-        subset: swe_Latn
-      - task: belebele_nob_Latn_cf
-        subset: nob_Latn
-      - task: belebele_eus_Latn_cf
-        subset: eus_Latn
-      - task: belebele_cat_Latn_cf
-        subset: cat_Latn
+      - task: "belebele_{lang}_cf"
+        subset: "{lang}"
       
   flores-200-eu-to-eng:
     description: "Flores 200 EU to English translation"
     suite: lighteval
     n_shots: [0]
     dataset: facebook/flores
+    valid_langs: [bul_Cyrl, ces_Latn, dan_Latn, deu_Latn, ell_Grek, est_Latn, fin_Latn, fra_Latn,
+                  gle_Latn, hrv_Latn, hun_Latn, ita_Latn, lit_Latn, lvs_Latn, mlt_Latn, nld_Latn,
+                  pol_Latn, por_Latn, ron_Latn, slk_Latn, slv_Latn, spa_Latn, swe_Latn]
     tasks:
-      - task: flores200:bul_Cyrl-eng_Latn
-      - task: flores200:ces_Latn-eng_Latn
-      - task: flores200:dan_Latn-eng_Latn
-      - task: flores200:deu_Latn-eng_Latn
-      - task: flores200:ell_Grek-eng_Latn
-      - task: flores200:est_Latn-eng_Latn
-      - task: flores200:fin_Latn-eng_Latn
-      - task: flores200:fra_Latn-eng_Latn
-      - task: flores200:gle_Latn-eng_Latn
-      - task: flores200:hrv_Latn-eng_Latn
-      - task: flores200:hun_Latn-eng_Latn
-      - task: flores200:ita_Latn-eng_Latn
-      - task: flores200:lit_Latn-eng_Latn
-      - task: flores200:lvs_Latn-eng_Latn
-      - task: flores200:mlt_Latn-eng_Latn
-      - task: flores200:nld_Latn-eng_Latn
-      - task: flores200:pol_Latn-eng_Latn
-      - task: flores200:por_Latn-eng_Latn
-      - task: flores200:ron_Latn-eng_Latn
-      - task: flores200:slk_Latn-eng_Latn
-      - task: flores200:slv_Latn-eng_Latn
-      - task: flores200:spa_Latn-eng_Latn
-      - task: flores200:swe_Latn-eng_Latn
+      - task: "flores200:{lang}-eng_Latn"
   flores-200-eng-to-eu:
     description: "Flores 200 English to EU translation"
     suite: lighteval
     n_shots: [0]
     dataset: facebook/flores
+    valid_langs: [bul_Cyrl, ces_Latn, dan_Latn, deu_Latn, ell_Grek, est_Latn, fin_Latn, fra_Latn,
+                  gle_Latn, hrv_Latn, hun_Latn, ita_Latn, lit_Latn, lvs_Latn, mlt_Latn, nld_Latn,
+                  pol_Latn, por_Latn, ron_Latn, slk_Latn, slv_Latn, spa_Latn, swe_Latn]
     tasks:
-      - task: flores200:eng_Latn-bul_Cyrl
-      - task: flores200:eng_Latn-ces_Latn
-      - task: flores200:eng_Latn-dan_Latn
-      - task: flores200:eng_Latn-deu_Latn
-      - task: flores200:eng_Latn-ell_Grek
-      - task: flores200:eng_Latn-est_Latn
-      - task: flores200:eng_Latn-fin_Latn
-      - task: flores200:eng_Latn-fra_Latn
-      - task: flores200:eng_Latn-gle_Latn
-      - task: flores200:eng_Latn-hrv_Latn
-      - task: flores200:eng_Latn-hun_Latn
-      - task: flores200:eng_Latn-ita_Latn
-      - task: flores200:eng_Latn-lit_Latn
-      - task: flores200:eng_Latn-lvs_Latn
-      - task: flores200:eng_Latn-mlt_Latn
-      - task: flores200:eng_Latn-nld_Latn
-      - task: flores200:eng_Latn-pol_Latn
-      - task: flores200:eng_Latn-por_Latn
-      - task: flores200:eng_Latn-ron_Latn
-      - task: flores200:eng_Latn-slk_Latn
-      - task: flores200:eng_Latn-slv_Latn
-      - task: flores200:eng_Latn-spa_Latn
-      - task: flores200:eng_Latn-swe_Latn
+      - task: "flores200:eng_Latn-{lang}"
   global-mmlu-eu:
     description: "Global MMLU EU tasks"
     suite: lm-eval-harness
     n_shots: [5]
     dataset: CohereForAI/Global-MMLU
+    valid_langs: [cs, de, el, en, es, fr, it, lt, nl, pl, pt, ro, ru, sr, sv, tr, uk, he]
     tasks:
-      - task: global_mmlu_full_cs
-        subset: cs
-      - task: global_mmlu_full_de
-        subset: de
-      - task: global_mmlu_full_el
-        subset: el
-      - task: global_mmlu_full_en
-        subset: en
-      - task: global_mmlu_full_es
-        subset: es
-      - task: global_mmlu_full_fr
-        subset: fr
-      - task: global_mmlu_full_it
-        subset: it
-      - task: global_mmlu_full_lt
-        subset: lt
-      - task: global_mmlu_full_nl
-        subset: nl
-      - task: global_mmlu_full_pl
-        subset: pl
-      - task: global_mmlu_full_pt
-        subset: pt
-      - task: global_mmlu_full_ro
-        subset: ro
-      - task: global_mmlu_full_ru
-        subset: ru
-      - task: global_mmlu_full_sr
-        subset: sr
-      - task: global_mmlu_full_sv
-        subset: sv
-      - task: global_mmlu_full_tr
-        subset: tr
-      - task: global_mmlu_full_uk
-        subset: uk
-      - task: global_mmlu_full_he
-        subset: he
+      - task: "global_mmlu_full_{lang}"
+        subset: "{lang}"
   mgsm-eu:
     description: "EU Language GSM benchmarks in Aya Expanse"
     suite: lm-eval-harness
@@ -677,50 +452,11 @@ task_groups:
     suite: lm-eval-harness
     n_shots: [0]
     dataset: LumiOpen/arc_challenge_mt
+    valid_langs: [bg, cs, da, nl, et, fi, fr, de, el, hu, it, lv, lt, pl, pt, ro, sk, sl, es, sv, nb]
     tasks:
-      - task: arc_challenge_mt_bg
-        subset: bg
-      - task: arc_challenge_mt_cs
-        subset: cs
-      - task: arc_challenge_mt_da
-        subset: da
-      - task: arc_challenge_mt_nl
-        subset: nl
-      - task: arc_challenge_mt_et
-        subset: et
-      - task: arc_challenge_mt_fi
-        subset: fi
-      - task: arc_challenge_mt_fr
-        subset: fr
-      - task: arc_challenge_mt_de
-        subset: de
-      - task: arc_challenge_mt_el
-        subset: el
-      - task: arc_challenge_mt_hu
-        subset: hu
-      - task: arc_challenge_mt_it
-        subset: it
-      - task: arc_challenge_mt_lv
-        subset: lv
-      - task: arc_challenge_mt_lt
-        subset: lt
-      - task: arc_challenge_mt_pl
-        subset: pl
-      - task: arc_challenge_mt_pt
-        subset: pt
-      - task: arc_challenge_mt_ro
-        subset: ro
-      - task: arc_challenge_mt_sk
-        subset: sk
-      - task: arc_challenge_mt_sl
-        subset: sl
-      - task: arc_challenge_mt_es
-        subset: es
-      - task: arc_challenge_mt_sv
-        subset: sv
-      - task: arc_challenge_mt_is
-      - task: arc_challenge_mt_nb
-        subset: nb
+      - task: "arc_challenge_mt_{lang}"
+        subset: "{lang}"
+      - task: arc_challenge_mt_is  # no subset in the source dataset
 
   reasoning:
     description: "Reasoning tasks: GSM8k (4-shot), IFEval (0-shot), MBPP (3-shot), GPQA-Diamond (0-shot), MATH500 (0-shot), LiveCodeBench (0-shot)"
@@ -752,142 +488,26 @@ task_groups:
     suite: lm-eval-harness
     n_shots: [0]
     dataset: mrlbenchmarks/global-piqa-nonparallel
+    valid_langs: [als_latn, bos_latn, bul_cyrl, cat_latn, ces_latn, deu_latn, ekk_latn, ell_grek,
+                  eng_latn, fin_latn, fra_latn_fran, glg_latn, hrv_latn, hun_latn, isl_latn, ita_latn,
+                  kat_geor, lit_latn, mkd_cyrl, nld_latn, nno_latn, nob_latn, pol_latn, por_latn_port,
+                  ron_latn, slk_latn, slv_latn, spa_latn_spai, srp_cyrl, swe_latn, tur_latn, ukr_cyrl]
     tasks:
-      - task: global_piqa_completions_als_latn
-        subset: als_latn
-      - task: global_piqa_completions_bos_latn
-        subset: bos_latn
-      - task: global_piqa_completions_bul_cyrl
-        subset: bul_cyrl
-      - task: global_piqa_completions_cat_latn
-        subset: cat_latn
-      - task: global_piqa_completions_ces_latn
-        subset: ces_latn
-      - task: global_piqa_completions_deu_latn
-        subset: deu_latn
-      - task: global_piqa_completions_ekk_latn
-        subset: ekk_latn
-      - task: global_piqa_completions_ell_grek
-        subset: ell_grek
-      - task: global_piqa_completions_eng_latn
-        subset: eng_latn
-      - task: global_piqa_completions_fin_latn
-        subset: fin_latn
-      - task: global_piqa_completions_fra_latn_fran
-        subset: fra_latn_fran
-      - task: global_piqa_completions_glg_latn
-        subset: glg_latn
-      - task: global_piqa_completions_hrv_latn
-        subset: hrv_latn
-      - task: global_piqa_completions_hun_latn
-        subset: hun_latn
-      - task: global_piqa_completions_isl_latn
-        subset: isl_latn
-      - task: global_piqa_completions_ita_latn
-        subset: ita_latn
-      - task: global_piqa_completions_kat_geor
-        subset: kat_geor
-      - task: global_piqa_completions_lit_latn
-        subset: lit_latn
-      - task: global_piqa_completions_mkd_cyrl
-        subset: mkd_cyrl
-      - task: global_piqa_completions_nld_latn
-        subset: nld_latn
-      - task: global_piqa_completions_nno_latn
-        subset: nno_latn
-      - task: global_piqa_completions_nob_latn
-        subset: nob_latn
-      - task: global_piqa_completions_pol_latn
-        subset: pol_latn
-      - task: global_piqa_completions_por_latn_port
-        subset: por_latn_port
-      - task: global_piqa_completions_ron_latn
-        subset: ron_latn
-      - task: global_piqa_completions_slk_latn
-        subset: slk_latn
-      - task: global_piqa_completions_slv_latn
-        subset: slv_latn
-      - task: global_piqa_completions_spa_latn_spai
-        subset: spa_latn_spai
-      - task: global_piqa_completions_srp_cyrl
-        subset: srp_cyrl
-      - task: global_piqa_completions_swe_latn
-        subset: swe_latn
-      - task: global_piqa_completions_tur_latn
-        subset: tur_latn
-      - task: global_piqa_completions_ukr_cyrl
-        subset: ukr_cyrl
+      - task: "global_piqa_completions_{lang}"
+        subset: "{lang}"
 
   global-piqa-eu-prompted:
     description: "Global PIQA European languages — prompted generation (0-shot, mrlbenchmarks/global-piqa-nonparallel)"
     suite: lm-eval-harness
     n_shots: [0]
     dataset: mrlbenchmarks/global-piqa-nonparallel
+    valid_langs: [als_latn, bos_latn, bul_cyrl, cat_latn, ces_latn, deu_latn, ekk_latn, ell_grek,
+                  eng_latn, fin_latn, fra_latn_fran, glg_latn, hrv_latn, hun_latn, isl_latn, ita_latn,
+                  kat_geor, lit_latn, mkd_cyrl, nld_latn, nno_latn, nob_latn, pol_latn, por_latn_port,
+                  ron_latn, slk_latn, slv_latn, spa_latn_spai, srp_cyrl, swe_latn, tur_latn, ukr_cyrl]
     tasks:
-      - task: global_piqa_prompted_als_latn
-        subset: als_latn
-      - task: global_piqa_prompted_bos_latn
-        subset: bos_latn
-      - task: global_piqa_prompted_bul_cyrl
-        subset: bul_cyrl
-      - task: global_piqa_prompted_cat_latn
-        subset: cat_latn
-      - task: global_piqa_prompted_ces_latn
-        subset: ces_latn
-      - task: global_piqa_prompted_deu_latn
-        subset: deu_latn
-      - task: global_piqa_prompted_ekk_latn
-        subset: ekk_latn
-      - task: global_piqa_prompted_ell_grek
-        subset: ell_grek
-      - task: global_piqa_prompted_eng_latn
-        subset: eng_latn
-      - task: global_piqa_prompted_fin_latn
-        subset: fin_latn
-      - task: global_piqa_prompted_fra_latn_fran
-        subset: fra_latn_fran
-      - task: global_piqa_prompted_glg_latn
-        subset: glg_latn
-      - task: global_piqa_prompted_hrv_latn
-        subset: hrv_latn
-      - task: global_piqa_prompted_hun_latn
-        subset: hun_latn
-      - task: global_piqa_prompted_isl_latn
-        subset: isl_latn
-      - task: global_piqa_prompted_ita_latn
-        subset: ita_latn
-      - task: global_piqa_prompted_kat_geor
-        subset: kat_geor
-      - task: global_piqa_prompted_lit_latn
-        subset: lit_latn
-      - task: global_piqa_prompted_mkd_cyrl
-        subset: mkd_cyrl
-      - task: global_piqa_prompted_nld_latn
-        subset: nld_latn
-      - task: global_piqa_prompted_nno_latn
-        subset: nno_latn
-      - task: global_piqa_prompted_nob_latn
-        subset: nob_latn
-      - task: global_piqa_prompted_pol_latn
-        subset: pol_latn
-      - task: global_piqa_prompted_por_latn_port
-        subset: por_latn_port
-      - task: global_piqa_prompted_ron_latn
-        subset: ron_latn
-      - task: global_piqa_prompted_slk_latn
-        subset: slk_latn
-      - task: global_piqa_prompted_slv_latn
-        subset: slv_latn
-      - task: global_piqa_prompted_spa_latn_spai
-        subset: spa_latn_spai
-      - task: global_piqa_prompted_srp_cyrl
-        subset: srp_cyrl
-      - task: global_piqa_prompted_swe_latn
-        subset: swe_latn
-      - task: global_piqa_prompted_tur_latn
-        subset: tur_latn
-      - task: global_piqa_prompted_ukr_cyrl
-        subset: ukr_cyrl
+      - task: "global_piqa_prompted_{lang}"
+        subset: "{lang}"
 
 super_groups:
   oellm-multilingual:

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -1,3 +1,4 @@
+import copy
 from collections.abc import Iterable
 from dataclasses import dataclass
 from importlib.resources import files
@@ -104,12 +105,47 @@ class TaskSuperGroup:
         )
 
 
+def _expand_lang_templates(data: dict) -> dict:
+    """Expand ``{lang}`` placeholders in task-group task entries.
+
+    A task group may declare a top-level ``valid_langs`` list.  Every task
+    entry whose ``task`` name or ``subset`` value contains the literal string
+    ``{lang}`` is expanded into one entry per language, with ``{lang}``
+    substituted by that language code.  Entries without ``{lang}`` are left
+    unchanged.  The ``valid_langs`` key is removed after expansion.
+    """
+    result = copy.deepcopy(data)
+    for group_data in result.get("task_groups", {}).values():
+        valid_langs = group_data.pop("valid_langs", None)
+        if not valid_langs:
+            continue
+        expanded: list[dict] = []
+        for task_data in group_data.get("tasks", []):
+            task_name = task_data.get("task", "")
+            subset = task_data.get("subset", "")
+            if "{lang}" in task_name or (subset and "{lang}" in subset):
+                for lang in valid_langs:
+                    entry = copy.deepcopy(task_data)
+                    entry["task"] = task_name.replace("{lang}", lang)
+                    if "subset" in entry:
+                        entry["subset"] = entry["subset"].replace("{lang}", lang)
+                    expanded.append(entry)
+            else:
+                expanded.append(task_data)
+        group_data["tasks"] = expanded
+    return result
+
+
+def _load_task_groups_data() -> dict:
+    """Load and pre-process the task-groups YAML, expanding any ``{lang}`` templates."""
+    raw = yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
+    return _expand_lang_templates(raw)
+
+
 def _parse_task_groups(
     requested_groups: list[str],
 ) -> dict[str, TaskSuperGroup | TaskGroup]:
-    data = (
-        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
-    )
+    data = _load_task_groups_data()
 
     task_groups: dict[str, TaskGroup] = {}
 
@@ -219,9 +255,7 @@ def _collect_dataset_specs(group_names: Iterable[str]) -> list[DatasetSpec]:
 
 def _build_task_dataset_map() -> dict[str, list[DatasetSpec]]:
     """Build a mapping from task names to their dataset specs from all task groups."""
-    data = (
-        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
-    )
+    data = _load_task_groups_data()
 
     all_group_names = list(data.get("task_groups", {}).keys())
     parsed = _parse_task_groups(all_group_names)
@@ -268,9 +302,7 @@ def _lookup_dataset_specs_for_tasks(task_names: Iterable[str]) -> list[DatasetSp
 
 def _build_task_suite_map() -> dict[str, str]:
     """Build a mapping from task names to their suite from all task groups."""
-    data = (
-        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
-    )
+    data = _load_task_groups_data()
 
     task_suite_map: dict[str, str] = {}
     for _, group_data in data.get("task_groups", {}).items():
@@ -286,7 +318,5 @@ def _build_task_suite_map() -> dict[str, str]:
 
 def get_all_task_group_names() -> list[str]:
     """Return all available task group names (excluding super_groups)."""
-    data = (
-        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
-    )
+    data = _load_task_groups_data()
     return list(data.get("task_groups", {}).keys())

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -138,7 +138,9 @@ def _expand_lang_templates(data: dict) -> dict:
 
 def _load_task_groups_data() -> dict:
     """Load and pre-process the task-groups YAML, expanding any ``{lang}`` templates."""
-    raw = yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
+    raw = (
+        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
+    )
     return _expand_lang_templates(raw)
 
 

--- a/tests/test_task_groups.py
+++ b/tests/test_task_groups.py
@@ -1,5 +1,3 @@
-import pytest
-
 from oellm.task_groups import (
     _expand_lang_templates,
     _expand_task_groups,

--- a/tests/test_task_groups.py
+++ b/tests/test_task_groups.py
@@ -1,0 +1,175 @@
+import pytest
+
+from oellm.task_groups import (
+    _expand_lang_templates,
+    _expand_task_groups,
+    _load_task_groups_data,
+)
+
+
+class TestExpandLangTemplates:
+    def test_no_valid_langs_unchanged(self):
+        data = {
+            "task_groups": {
+                "my-group": {
+                    "suite": "lm-eval-harness",
+                    "tasks": [{"task": "arc_challenge", "n_shots": [0]}],
+                }
+            }
+        }
+        result = _expand_lang_templates(data)
+        assert result == data
+
+    def test_task_template_expanded(self):
+        data = {
+            "task_groups": {
+                "my-group": {
+                    "suite": "lm-eval-harness",
+                    "valid_langs": ["en", "de"],
+                    "tasks": [{"task": "foo_{lang}", "subset": "{lang}"}],
+                }
+            }
+        }
+        result = _expand_lang_templates(data)
+        tasks = result["task_groups"]["my-group"]["tasks"]
+        assert tasks == [
+            {"task": "foo_en", "subset": "en"},
+            {"task": "foo_de", "subset": "de"},
+        ]
+
+    def test_valid_langs_key_removed(self):
+        data = {
+            "task_groups": {
+                "my-group": {
+                    "suite": "lm-eval-harness",
+                    "valid_langs": ["en"],
+                    "tasks": [{"task": "foo_{lang}"}],
+                }
+            }
+        }
+        result = _expand_lang_templates(data)
+        assert "valid_langs" not in result["task_groups"]["my-group"]
+
+    def test_non_template_tasks_preserved(self):
+        data = {
+            "task_groups": {
+                "my-group": {
+                    "suite": "lm-eval-harness",
+                    "valid_langs": ["en", "de"],
+                    "tasks": [
+                        {"task": "foo_{lang}", "subset": "{lang}"},
+                        {"task": "bar_static"},
+                    ],
+                }
+            }
+        }
+        result = _expand_lang_templates(data)
+        tasks = result["task_groups"]["my-group"]["tasks"]
+        assert len(tasks) == 3
+        assert tasks[0] == {"task": "foo_en", "subset": "en"}
+        assert tasks[1] == {"task": "foo_de", "subset": "de"}
+        assert tasks[2] == {"task": "bar_static"}
+
+    def test_does_not_mutate_input(self):
+        data = {
+            "task_groups": {
+                "my-group": {
+                    "suite": "lm-eval-harness",
+                    "valid_langs": ["en"],
+                    "tasks": [{"task": "foo_{lang}"}],
+                }
+            }
+        }
+        _expand_lang_templates(data)
+        assert "valid_langs" in data["task_groups"]["my-group"]
+        assert data["task_groups"]["my-group"]["tasks"] == [{"task": "foo_{lang}"}]
+
+    def test_task_only_template_no_subset(self):
+        """Template in task name only, no subset field."""
+        data = {
+            "task_groups": {
+                "flores": {
+                    "suite": "lighteval",
+                    "valid_langs": ["bul_Cyrl", "ces_Latn"],
+                    "tasks": [{"task": "flores200:{lang}-eng_Latn"}],
+                }
+            }
+        }
+        result = _expand_lang_templates(data)
+        tasks = result["task_groups"]["flores"]["tasks"]
+        assert tasks == [
+            {"task": "flores200:bul_Cyrl-eng_Latn"},
+            {"task": "flores200:ces_Latn-eng_Latn"},
+        ]
+
+
+class TestLoadTaskGroupsData:
+    def test_returns_dict_with_task_groups(self):
+        data = _load_task_groups_data()
+        assert "task_groups" in data
+        assert isinstance(data["task_groups"], dict)
+
+    def test_no_valid_langs_in_expanded_data(self):
+        """After loading, no task group should have valid_langs remaining."""
+        data = _load_task_groups_data()
+        for name, group in data["task_groups"].items():
+            assert "valid_langs" not in group, f"valid_langs still present in {name}"
+
+    def test_no_lang_placeholder_in_task_names(self):
+        """After loading, no task entry should contain the {lang} placeholder."""
+        data = _load_task_groups_data()
+        for group_name, group in data["task_groups"].items():
+            for task in group.get("tasks", []):
+                assert "{lang}" not in task.get("task", ""), (
+                    f"Unexpanded {{lang}} in task '{task['task']}' of group '{group_name}'"
+                )
+
+
+class TestBackwardCompatibility:
+    def test_open_sci_task_count(self):
+        """Groups without valid_langs (e.g. open-sci-0.01) are unaffected."""
+        results = _expand_task_groups(["open-sci-0.01"])
+        # 12 tasks, hellaswag has n_shots=[10] => 12 results
+        assert len(results) == 12
+
+    def test_open_sci_no_lang_placeholders(self):
+        results = _expand_task_groups(["open-sci-0.01"])
+        for r in results:
+            assert "{lang}" not in r.task
+
+    def test_open_sci_task_names_unchanged(self):
+        results = _expand_task_groups(["open-sci-0.01"])
+        task_names = {r.task for r in results}
+        assert "arc_challenge" in task_names
+        assert "hellaswag" in task_names
+        assert "mmlu" in task_names
+
+
+class TestExpandTaskGroupsWithTemplates:
+    def test_sib200_expands_to_36_tasks(self):
+        results = _expand_task_groups(["sib200-eu"])
+        assert len(results) == 36
+
+    def test_belebele_cf_expands_to_26_tasks(self):
+        results = _expand_task_groups(["belebele-eu-cf"])
+        assert len(results) == 26
+
+    def test_arc_challenge_mt_expands_to_22_tasks(self):
+        # 21 templated + 1 static (arc_challenge_mt_is)
+        results = _expand_task_groups(["arc-challenge-mt-eu"])
+        assert len(results) == 22
+        task_names = {r.task for r in results}
+        assert "arc_challenge_mt_is" in task_names
+        assert "arc_challenge_mt_bg" in task_names
+
+    def test_flores_eu_to_eng_expands_to_23_tasks(self):
+        results = _expand_task_groups(["flores-200-eu-to-eng"])
+        assert len(results) == 23
+
+    def test_global_mmlu_expands_to_18_tasks(self):
+        results = _expand_task_groups(["global-mmlu-eu"])
+        assert len(results) == 18
+
+    def test_global_piqa_completions_expands_to_32_tasks(self):
+        results = _expand_task_groups(["global-piqa-eu-completions"])
+        assert len(results) == 32


### PR DESCRIPTION
## Add `{lang}` template expansion for task groups

Addresses the repetition problem in PRs that add multilingual benchmarks — previously each new language required two explicit lines in the YAML, leading to PRs with hundreds of near-identical lines.

### What changed

**`oellm/task_groups.py`**
- Add `_expand_lang_templates(data)`: deep-copies the YAML dict and expands any task entry whose `task`/`subset` contains `{lang}` into one entry per language listed under `valid_langs`, then removes the `valid_langs` key. Groups without `valid_langs` are untouched.
- Add `_load_task_groups_data()`: single YAML loading entry point that applies template expansion; replaces four separate `yaml.safe_load()` calls.

**`oellm/resources/task-groups.yaml`**
- Convert 9 repetitive groups to the new template syntax:
  `sib200-eu`, `belebele-eu-5-shot`, `belebele-eu-cf`,
  `flores-200-eu-to-eng`, `flores-200-eng-to-eu`, `global-mmlu-eu`,
  `arc-challenge-mt-eu`, `global-piqa-eu-completions`,
  `global-piqa-eu-prompted`
- All `valid_langs` use a consistent inline flow style.

**`tests/test_task_groups.py`** (new)
- 18 tests covering: template expansion correctness, no input mutation, post-expansion invariants (no residual `{lang}` or `valid_langs`), per-group task counts, and backward compatibility for plain groups.

### Backward compatibility

Groups without `valid_langs` (e.g. `open-sci-0.01`, `dclm-core-22`, `include`) are completely unaffected. The expansion is a no-op when the key is absent.

### New syntax example

```yaml
global-mgsm:
  description: "Global-MGSM multilingual math benchmarks"
  suite: lm-eval-harness
  n_shots: [0]
  dataset: CohereLabs/global-mgsm
  valid_langs: [de, bn, es, fr, ja, ru, sw, te, th, zh]
  tasks:
    - task: "global_mgsm_{lang}"
      subset: "{lang}"
```