### PR TITLE
Add Language Task Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,29 @@ oellm-eval schedule --models "model-name" --task_groups "belebele-eu-5-shot,glob
 oellm-eval schedule --models "model-name" --task_groups "oellm-multilingual"
 ```
 
+### Per-language task groups
+
+Every language-specific task is tagged with a `languages:` field in
+[`task-groups.yaml`](oellm/resources/task-groups.yaml), and a task group is
+automatically derived for each language code. This lets you run *all* available
+evaluations for one language (across SIB-200, Belebele, Global-MMLU, ARC-MT,
+Global-PIQA, INCLUDE, MGSM, FLORES, …) with a single canonical
+[`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag) code:
+
+```bash
+# All German evaluations
+oellm-eval schedule --models "my-datamix-model" --task_groups "deu_Latn"
+
+# Several monolingual models against their own language
+oellm-eval schedule --models "model" --task_groups "fra_Latn,ita_Latn,por_Latn"
+```
+
+Language groups span both `lm-eval-harness` and `lighteval` tasks transparently
+(each task keeps its own suite). To add a new multilingual benchmark, tag its
+tasks with `languages:` (see [docs/TASKS.md](docs/TASKS.md)) — they then flow
+into the relevant language groups automatically. `scripts/tag_languages.py`
+normalises the various per-benchmark language spellings into the canonical code.
+
 ## Running Locally (without SLURM)
 
 The `--local` flag lets you run evaluations directly on your machine without a cluster or Singularity container. It generates the same eval script and executes it with bash, injecting fake SLURM environment variables so all tasks run sequentially in a single process. This is useful for testing that tasks and models are correctly configured before submitting to a cluster.

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -178,76 +178,112 @@ task_groups:
     dataset: Davlan/sib200
     tasks:
       - task: sib200_bul_Cyrl
+        languages: [bul_Cyrl]
         subset: bul_Cyrl
       - task: sib200_hrv_Latn
+        languages: [hrv_Latn]
         subset: hrv_Latn
       - task: sib200_ces_Latn
+        languages: [ces_Latn]
         subset: ces_Latn
       - task: sib200_dan_Latn
+        languages: [dan_Latn]
         subset: dan_Latn
       - task: sib200_nld_Latn
+        languages: [nld_Latn]
         subset: nld_Latn
       - task: sib200_eng_Latn
+        languages: [eng_Latn]
         subset: eng_Latn
       - task: sib200_est_Latn
+        languages: [est_Latn]
         subset: est_Latn
       - task: sib200_fin_Latn
+        languages: [fin_Latn]
         subset: fin_Latn
       - task: sib200_fra_Latn
+        languages: [fra_Latn]
         subset: fra_Latn
       - task: sib200_deu_Latn
+        languages: [deu_Latn]
         subset: deu_Latn
       - task: sib200_ell_Grek
+        languages: [ell_Grek]
         subset: ell_Grek
       - task: sib200_hun_Latn
+        languages: [hun_Latn]
         subset: hun_Latn
       - task: sib200_gle_Latn
+        languages: [gle_Latn]
         subset: gle_Latn
       - task: sib200_ita_Latn
+        languages: [ita_Latn]
         subset: ita_Latn
       - task: sib200_lvs_Latn
+        languages: [lvs_Latn]
         subset: lvs_Latn
       - task: sib200_lit_Latn
+        languages: [lit_Latn]
         subset: lit_Latn
       - task: sib200_mlt_Latn
+        languages: [mlt_Latn]
         subset: mlt_Latn
       - task: sib200_pol_Latn
+        languages: [pol_Latn]
         subset: pol_Latn
       - task: sib200_por_Latn
+        languages: [por_Latn]
         subset: por_Latn
       - task: sib200_ron_Latn
+        languages: [ron_Latn]
         subset: ron_Latn
       - task: sib200_slk_Latn
+        languages: [slk_Latn]
         subset: slk_Latn
       - task: sib200_slv_Latn
+        languages: [slv_Latn]
         subset: slv_Latn
       - task: sib200_spa_Latn
+        languages: [spa_Latn]
         subset: spa_Latn
       - task: sib200_swe_Latn
+        languages: [swe_Latn]
         subset: swe_Latn
       - task: sib200_cat_Latn
+        languages: [cat_Latn]
         subset: cat_Latn
       - task: sib200_eus_Latn
+        languages: [eus_Latn]
         subset: eus_Latn
       - task: sib200_glg_Latn
+        languages: [glg_Latn]
         subset: glg_Latn
       - task: sib200_bos_Latn
+        languages: [bos_Latn]
         subset: bos_Latn
       - task: sib200_kat_Geor
+        languages: [kat_Geor]
         subset: kat_Geor
       - task: sib200_mkd_Cyrl
+        languages: [mkd_Cyrl]
         subset: mkd_Cyrl
       - task: sib200_als_Latn
+        languages: [als_Latn]
         subset: als_Latn
       - task: sib200_srp_Cyrl
+        languages: [srp_Cyrl]
         subset: srp_Cyrl
       - task: sib200_tur_Latn
+        languages: [tur_Latn]
         subset: tur_Latn
       - task: sib200_ukr_Cyrl
+        languages: [ukr_Cyrl]
         subset: ukr_Cyrl
       - task: sib200_isl_Latn
+        languages: [isl_Latn]
         subset: isl_Latn
       - task: sib200_nob_Latn
+        languages: [nob_Latn]
         subset: nob_Latn
   open-sci-0.01:
     description: "open-sci-ref 0.01 evals"
@@ -301,52 +337,76 @@ task_groups:
     dataset: facebook/belebele
     tasks:
       - task: belebele_bul_Cyrl
+        languages: [bul_Cyrl]
         subset: bul_Cyrl
       - task: belebele_hrv_Latn
+        languages: [hrv_Latn]
         subset: hrv_Latn
       - task: belebele_ces_Latn
+        languages: [ces_Latn]
         subset: ces_Latn
       - task: belebele_dan_Latn
+        languages: [dan_Latn]
         subset: dan_Latn
       - task: belebele_nld_Latn
+        languages: [nld_Latn]
         subset: nld_Latn
       - task: belebele_eng_Latn
+        languages: [eng_Latn]
         subset: eng_Latn
       - task: belebele_est_Latn
+        languages: [est_Latn]
         subset: est_Latn
       - task: belebele_fin_Latn
+        languages: [fin_Latn]
         subset: fin_Latn
       - task: belebele_fra_Latn
+        languages: [fra_Latn]
         subset: fra_Latn
       - task: belebele_deu_Latn
+        languages: [deu_Latn]
         subset: deu_Latn
       - task: belebele_ell_Grek
+        languages: [ell_Grek]
         subset: ell_Grek
       - task: belebele_hun_Latn
+        languages: [hun_Latn]
         subset: hun_Latn
       - task: belebele_ita_Latn
+        languages: [ita_Latn]
         subset: ita_Latn
       - task: belebele_lvs_Latn
+        languages: [lvs_Latn]
         subset: lvs_Latn
       - task: belebele_lit_Latn
+        languages: [lit_Latn]
         subset: lit_Latn
       - task: belebele_mlt_Latn
+        languages: [mlt_Latn]
         subset: mlt_Latn
       - task: belebele_pol_Latn
+        languages: [pol_Latn]
         subset: pol_Latn
       - task: belebele_por_Latn
+        languages: [por_Latn]
         subset: por_Latn
       - task: belebele_ron_Latn
+        languages: [ron_Latn]
         subset: ron_Latn
       - task: belebele_slk_Latn
+        languages: [slk_Latn]
         subset: slk_Latn
       - task: belebele_slv_Latn
+        languages: [slv_Latn]
         subset: slv_Latn
       - task: belebele_spa_Latn
+        languages: [spa_Latn]
         subset: spa_Latn
       - task: belebele_swe_Latn
+        languages: [swe_Latn]
         subset: swe_Latn
       - task: belebele_nob_Latn
+        languages: [nob_Latn]
         subset: nob_Latn
   belebele-eu-cf:
     description: "Belebele European language tasks (cloze formulation, lighteval)"
@@ -355,56 +415,82 @@ task_groups:
     dataset: facebook/belebele
     tasks:
       - task: belebele_bul_Cyrl_cf
+        languages: [bul_Cyrl]
         subset: bul_Cyrl
       - task: belebele_hrv_Latn_cf
+        languages: [hrv_Latn]
         subset: hrv_Latn
       - task: belebele_ces_Latn_cf
+        languages: [ces_Latn]
         subset: ces_Latn
       - task: belebele_dan_Latn_cf
+        languages: [dan_Latn]
         subset: dan_Latn
       - task: belebele_nld_Latn_cf
+        languages: [nld_Latn]
         subset: nld_Latn
       - task: belebele_eng_Latn_cf
+        languages: [eng_Latn]
         subset: eng_Latn
       - task: belebele_est_Latn_cf
+        languages: [est_Latn]
         subset: est_Latn
       - task: belebele_fin_Latn_cf
+        languages: [fin_Latn]
         subset: fin_Latn
       - task: belebele_fra_Latn_cf
+        languages: [fra_Latn]
         subset: fra_Latn
       - task: belebele_deu_Latn_cf
+        languages: [deu_Latn]
         subset: deu_Latn
       - task: belebele_ell_Grek_cf
+        languages: [ell_Grek]
         subset: ell_Grek
       - task: belebele_hun_Latn_cf
+        languages: [hun_Latn]
         subset: hun_Latn
       - task: belebele_ita_Latn_cf
+        languages: [ita_Latn]
         subset: ita_Latn
       - task: belebele_lvs_Latn_cf
+        languages: [lvs_Latn]
         subset: lvs_Latn
       - task: belebele_lit_Latn_cf
+        languages: [lit_Latn]
         subset: lit_Latn
       - task: belebele_mlt_Latn_cf
+        languages: [mlt_Latn]
         subset: mlt_Latn
       - task: belebele_pol_Latn_cf
+        languages: [pol_Latn]
         subset: pol_Latn
       - task: belebele_por_Latn_cf
+        languages: [por_Latn]
         subset: por_Latn
       - task: belebele_ron_Latn_cf
+        languages: [ron_Latn]
         subset: ron_Latn
       - task: belebele_slk_Latn_cf
+        languages: [slk_Latn]
         subset: slk_Latn
       - task: belebele_slv_Latn_cf
+        languages: [slv_Latn]
         subset: slv_Latn
       - task: belebele_spa_Latn_cf
+        languages: [spa_Latn]
         subset: spa_Latn
       - task: belebele_swe_Latn_cf
+        languages: [swe_Latn]
         subset: swe_Latn
       - task: belebele_nob_Latn_cf
+        languages: [nob_Latn]
         subset: nob_Latn
       - task: belebele_eus_Latn_cf
+        languages: [eus_Latn]
         subset: eus_Latn
       - task: belebele_cat_Latn_cf
+        languages: [cat_Latn]
         subset: cat_Latn
       
   flores-200-eu-to-eng:
@@ -414,28 +500,51 @@ task_groups:
     dataset: facebook/flores
     tasks:
       - task: flores200:bul_Cyrl-eng_Latn
+        languages: [bul_Cyrl]
       - task: flores200:ces_Latn-eng_Latn
+        languages: [ces_Latn]
       - task: flores200:dan_Latn-eng_Latn
+        languages: [dan_Latn]
       - task: flores200:deu_Latn-eng_Latn
+        languages: [deu_Latn]
       - task: flores200:ell_Grek-eng_Latn
+        languages: [ell_Grek]
       - task: flores200:est_Latn-eng_Latn
+        languages: [est_Latn]
       - task: flores200:fin_Latn-eng_Latn
+        languages: [fin_Latn]
       - task: flores200:fra_Latn-eng_Latn
+        languages: [fra_Latn]
       - task: flores200:gle_Latn-eng_Latn
+        languages: [gle_Latn]
       - task: flores200:hrv_Latn-eng_Latn
+        languages: [hrv_Latn]
       - task: flores200:hun_Latn-eng_Latn
+        languages: [hun_Latn]
       - task: flores200:ita_Latn-eng_Latn
+        languages: [ita_Latn]
       - task: flores200:lit_Latn-eng_Latn
+        languages: [lit_Latn]
       - task: flores200:lvs_Latn-eng_Latn
+        languages: [lvs_Latn]
       - task: flores200:mlt_Latn-eng_Latn
+        languages: [mlt_Latn]
       - task: flores200:nld_Latn-eng_Latn
+        languages: [nld_Latn]
       - task: flores200:pol_Latn-eng_Latn
+        languages: [pol_Latn]
       - task: flores200:por_Latn-eng_Latn
+        languages: [por_Latn]
       - task: flores200:ron_Latn-eng_Latn
+        languages: [ron_Latn]
       - task: flores200:slk_Latn-eng_Latn
+        languages: [slk_Latn]
       - task: flores200:slv_Latn-eng_Latn
+        languages: [slv_Latn]
       - task: flores200:spa_Latn-eng_Latn
+        languages: [spa_Latn]
       - task: flores200:swe_Latn-eng_Latn
+        languages: [swe_Latn]
   flores-200-eng-to-eu:
     description: "Flores 200 English to EU translation"
     suite: lighteval
@@ -443,28 +552,51 @@ task_groups:
     dataset: facebook/flores
     tasks:
       - task: flores200:eng_Latn-bul_Cyrl
+        languages: [bul_Cyrl]
       - task: flores200:eng_Latn-ces_Latn
+        languages: [ces_Latn]
       - task: flores200:eng_Latn-dan_Latn
+        languages: [dan_Latn]
       - task: flores200:eng_Latn-deu_Latn
+        languages: [deu_Latn]
       - task: flores200:eng_Latn-ell_Grek
+        languages: [ell_Grek]
       - task: flores200:eng_Latn-est_Latn
+        languages: [est_Latn]
       - task: flores200:eng_Latn-fin_Latn
+        languages: [fin_Latn]
       - task: flores200:eng_Latn-fra_Latn
+        languages: [fra_Latn]
       - task: flores200:eng_Latn-gle_Latn
+        languages: [gle_Latn]
       - task: flores200:eng_Latn-hrv_Latn
+        languages: [hrv_Latn]
       - task: flores200:eng_Latn-hun_Latn
+        languages: [hun_Latn]
       - task: flores200:eng_Latn-ita_Latn
+        languages: [ita_Latn]
       - task: flores200:eng_Latn-lit_Latn
+        languages: [lit_Latn]
       - task: flores200:eng_Latn-lvs_Latn
+        languages: [lvs_Latn]
       - task: flores200:eng_Latn-mlt_Latn
+        languages: [mlt_Latn]
       - task: flores200:eng_Latn-nld_Latn
+        languages: [nld_Latn]
       - task: flores200:eng_Latn-pol_Latn
+        languages: [pol_Latn]
       - task: flores200:eng_Latn-por_Latn
+        languages: [por_Latn]
       - task: flores200:eng_Latn-ron_Latn
+        languages: [ron_Latn]
       - task: flores200:eng_Latn-slk_Latn
+        languages: [slk_Latn]
       - task: flores200:eng_Latn-slv_Latn
+        languages: [slv_Latn]
       - task: flores200:eng_Latn-spa_Latn
+        languages: [spa_Latn]
       - task: flores200:eng_Latn-swe_Latn
+        languages: [swe_Latn]
   global-mmlu-eu:
     description: "Global MMLU EU tasks"
     suite: lm-eval-harness
@@ -472,40 +604,58 @@ task_groups:
     dataset: CohereForAI/Global-MMLU
     tasks:
       - task: global_mmlu_full_cs
+        languages: [ces_Latn]
         subset: cs
       - task: global_mmlu_full_de
+        languages: [deu_Latn]
         subset: de
       - task: global_mmlu_full_el
+        languages: [ell_Grek]
         subset: el
       - task: global_mmlu_full_en
+        languages: [eng_Latn]
         subset: en
       - task: global_mmlu_full_es
+        languages: [spa_Latn]
         subset: es
       - task: global_mmlu_full_fr
+        languages: [fra_Latn]
         subset: fr
       - task: global_mmlu_full_it
+        languages: [ita_Latn]
         subset: it
       - task: global_mmlu_full_lt
+        languages: [lit_Latn]
         subset: lt
       - task: global_mmlu_full_nl
+        languages: [nld_Latn]
         subset: nl
       - task: global_mmlu_full_pl
+        languages: [pol_Latn]
         subset: pl
       - task: global_mmlu_full_pt
+        languages: [por_Latn]
         subset: pt
       - task: global_mmlu_full_ro
+        languages: [ron_Latn]
         subset: ro
       - task: global_mmlu_full_ru
+        languages: [rus_Cyrl]
         subset: ru
       - task: global_mmlu_full_sr
+        languages: [srp_Cyrl]
         subset: sr
       - task: global_mmlu_full_sv
+        languages: [swe_Latn]
         subset: sv
       - task: global_mmlu_full_tr
+        languages: [tur_Latn]
         subset: tr
       - task: global_mmlu_full_uk
+        languages: [ukr_Cyrl]
         subset: uk
       - task: global_mmlu_full_he
+        languages: [heb_Hebr]
         subset: he
   mgsm-eu:
     description: "EU Language GSM benchmarks in Aya Expanse"
@@ -514,12 +664,16 @@ task_groups:
     dataset: jbross-ibm-research/mgsm
     tasks:
       - task: mgsm_native_cot_en
+        languages: [eng_Latn]
         subset: en
       - task: mgsm_native_cot_de
+        languages: [deu_Latn]
         subset: de
       - task: mgsm_native_cot_es
+        languages: [spa_Latn]
         subset: es
       - task: mgsm_native_cot_fr
+        languages: [fra_Latn]
         subset: fr
 
   generic-multilingual:
@@ -541,54 +695,79 @@ task_groups:
     dataset: CohereForAI/include-base-44
     tasks:
       - task: include_base_44_albanian
+        languages: [als_Latn]
         subset: Albanian
       - task: include_base_44_armenian
+        languages: [hye_Armn]
         subset: Armenian
       - task: include_base_44_azerbaijani
+        languages: [aze_Latn]
         subset: Azerbaijani
       - task: include_base_44_basque
+        languages: [eus_Latn]
         subset: Basque
       - task: include_base_44_belarusian
+        languages: [bel_Cyrl]
         subset: Belarusian
       - task: include_base_44_bulgarian
+        languages: [bul_Cyrl]
         subset: Bulgarian
       - task: include_base_44_croatian
+        languages: [hrv_Latn]
         subset: Croatian
       - task: include_base_44_dutch
+        languages: [nld_Latn]
         subset: Dutch
       - task: include_base_44_estonian
+        languages: [est_Latn]
         subset: Estonian
       - task: include_base_44_finnish
+        languages: [fin_Latn]
         subset: Finnish
       - task: include_base_44_french
+        languages: [fra_Latn]
         subset: French
       - task: include_base_44_georgian
+        languages: [kat_Geor]
         subset: Georgian
       - task: include_base_44_german
+        languages: [deu_Latn]
         subset: German
       - task: include_base_44_greek
+        languages: [ell_Grek]
         subset: Greek
       - task: include_base_44_hungarian
+        languages: [hun_Latn]
         subset: Hungarian
       - task: include_base_44_italian
+        languages: [ita_Latn]
         subset: Italian
       - task: include_base_44_lithuanian
+        languages: [lit_Latn]
         subset: Lithuanian
       - task: include_base_44_north macedonian
+        languages: [mkd_Cyrl]
         subset: North Macedonian
       - task: include_base_44_polish
+        languages: [pol_Latn]
         subset: Polish
       - task: include_base_44_portuguese
+        languages: [por_Latn]
         subset: Portuguese
       - task: include_base_44_russian
+        languages: [rus_Cyrl]
         subset: Russian
       - task: include_base_44_serbian
+        languages: [srp_Cyrl]
         subset: Serbian
       - task: include_base_44_spanish
+        languages: [spa_Latn]
         subset: Spanish
       - task: include_base_44_turkish
+        languages: [tur_Latn]
         subset: Turkish
       - task: include_base_44_ukrainian
+        languages: [ukr_Cyrl]
         subset: Ukrainian
 
   dclm-core-22:
@@ -679,47 +858,69 @@ task_groups:
     dataset: LumiOpen/arc_challenge_mt
     tasks:
       - task: arc_challenge_mt_bg
+        languages: [bul_Cyrl]
         subset: bg
       - task: arc_challenge_mt_cs
+        languages: [ces_Latn]
         subset: cs
       - task: arc_challenge_mt_da
+        languages: [dan_Latn]
         subset: da
       - task: arc_challenge_mt_nl
+        languages: [nld_Latn]
         subset: nl
       - task: arc_challenge_mt_et
+        languages: [est_Latn]
         subset: et
       - task: arc_challenge_mt_fi
+        languages: [fin_Latn]
         subset: fi
       - task: arc_challenge_mt_fr
+        languages: [fra_Latn]
         subset: fr
       - task: arc_challenge_mt_de
+        languages: [deu_Latn]
         subset: de
       - task: arc_challenge_mt_el
+        languages: [ell_Grek]
         subset: el
       - task: arc_challenge_mt_hu
+        languages: [hun_Latn]
         subset: hu
       - task: arc_challenge_mt_it
+        languages: [ita_Latn]
         subset: it
       - task: arc_challenge_mt_lv
+        languages: [lvs_Latn]
         subset: lv
       - task: arc_challenge_mt_lt
+        languages: [lit_Latn]
         subset: lt
       - task: arc_challenge_mt_pl
+        languages: [pol_Latn]
         subset: pl
       - task: arc_challenge_mt_pt
+        languages: [por_Latn]
         subset: pt
       - task: arc_challenge_mt_ro
+        languages: [ron_Latn]
         subset: ro
       - task: arc_challenge_mt_sk
+        languages: [slk_Latn]
         subset: sk
       - task: arc_challenge_mt_sl
+        languages: [slv_Latn]
         subset: sl
       - task: arc_challenge_mt_es
+        languages: [spa_Latn]
         subset: es
       - task: arc_challenge_mt_sv
+        languages: [swe_Latn]
         subset: sv
       - task: arc_challenge_mt_is
+        languages: [isl_Latn]
       - task: arc_challenge_mt_nb
+        languages: [nob_Latn]
         subset: nb
 
   reasoning:
@@ -754,68 +955,100 @@ task_groups:
     dataset: mrlbenchmarks/global-piqa-nonparallel
     tasks:
       - task: global_piqa_completions_als_latn
+        languages: [als_Latn]
         subset: als_latn
       - task: global_piqa_completions_bos_latn
+        languages: [bos_Latn]
         subset: bos_latn
       - task: global_piqa_completions_bul_cyrl
+        languages: [bul_Cyrl]
         subset: bul_cyrl
       - task: global_piqa_completions_cat_latn
+        languages: [cat_Latn]
         subset: cat_latn
       - task: global_piqa_completions_ces_latn
+        languages: [ces_Latn]
         subset: ces_latn
       - task: global_piqa_completions_deu_latn
+        languages: [deu_Latn]
         subset: deu_latn
       - task: global_piqa_completions_ekk_latn
+        languages: [est_Latn]
         subset: ekk_latn
       - task: global_piqa_completions_ell_grek
+        languages: [ell_Grek]
         subset: ell_grek
       - task: global_piqa_completions_eng_latn
+        languages: [eng_Latn]
         subset: eng_latn
       - task: global_piqa_completions_fin_latn
+        languages: [fin_Latn]
         subset: fin_latn
       - task: global_piqa_completions_fra_latn_fran
+        languages: [fra_Latn]
         subset: fra_latn_fran
       - task: global_piqa_completions_glg_latn
+        languages: [glg_Latn]
         subset: glg_latn
       - task: global_piqa_completions_hrv_latn
+        languages: [hrv_Latn]
         subset: hrv_latn
       - task: global_piqa_completions_hun_latn
+        languages: [hun_Latn]
         subset: hun_latn
       - task: global_piqa_completions_isl_latn
+        languages: [isl_Latn]
         subset: isl_latn
       - task: global_piqa_completions_ita_latn
+        languages: [ita_Latn]
         subset: ita_latn
       - task: global_piqa_completions_kat_geor
+        languages: [kat_Geor]
         subset: kat_geor
       - task: global_piqa_completions_lit_latn
+        languages: [lit_Latn]
         subset: lit_latn
       - task: global_piqa_completions_mkd_cyrl
+        languages: [mkd_Cyrl]
         subset: mkd_cyrl
       - task: global_piqa_completions_nld_latn
+        languages: [nld_Latn]
         subset: nld_latn
       - task: global_piqa_completions_nno_latn
+        languages: [nno_Latn]
         subset: nno_latn
       - task: global_piqa_completions_nob_latn
+        languages: [nob_Latn]
         subset: nob_latn
       - task: global_piqa_completions_pol_latn
+        languages: [pol_Latn]
         subset: pol_latn
       - task: global_piqa_completions_por_latn_port
+        languages: [por_Latn]
         subset: por_latn_port
       - task: global_piqa_completions_ron_latn
+        languages: [ron_Latn]
         subset: ron_latn
       - task: global_piqa_completions_slk_latn
+        languages: [slk_Latn]
         subset: slk_latn
       - task: global_piqa_completions_slv_latn
+        languages: [slv_Latn]
         subset: slv_latn
       - task: global_piqa_completions_spa_latn_spai
+        languages: [spa_Latn]
         subset: spa_latn_spai
       - task: global_piqa_completions_srp_cyrl
+        languages: [srp_Cyrl]
         subset: srp_cyrl
       - task: global_piqa_completions_swe_latn
+        languages: [swe_Latn]
         subset: swe_latn
       - task: global_piqa_completions_tur_latn
+        languages: [tur_Latn]
         subset: tur_latn
       - task: global_piqa_completions_ukr_cyrl
+        languages: [ukr_Cyrl]
         subset: ukr_cyrl
 
   global-piqa-eu-prompted:
@@ -825,68 +1058,100 @@ task_groups:
     dataset: mrlbenchmarks/global-piqa-nonparallel
     tasks:
       - task: global_piqa_prompted_als_latn
+        languages: [als_Latn]
         subset: als_latn
       - task: global_piqa_prompted_bos_latn
+        languages: [bos_Latn]
         subset: bos_latn
       - task: global_piqa_prompted_bul_cyrl
+        languages: [bul_Cyrl]
         subset: bul_cyrl
       - task: global_piqa_prompted_cat_latn
+        languages: [cat_Latn]
         subset: cat_latn
       - task: global_piqa_prompted_ces_latn
+        languages: [ces_Latn]
         subset: ces_latn
       - task: global_piqa_prompted_deu_latn
+        languages: [deu_Latn]
         subset: deu_latn
       - task: global_piqa_prompted_ekk_latn
+        languages: [est_Latn]
         subset: ekk_latn
       - task: global_piqa_prompted_ell_grek
+        languages: [ell_Grek]
         subset: ell_grek
       - task: global_piqa_prompted_eng_latn
+        languages: [eng_Latn]
         subset: eng_latn
       - task: global_piqa_prompted_fin_latn
+        languages: [fin_Latn]
         subset: fin_latn
       - task: global_piqa_prompted_fra_latn_fran
+        languages: [fra_Latn]
         subset: fra_latn_fran
       - task: global_piqa_prompted_glg_latn
+        languages: [glg_Latn]
         subset: glg_latn
       - task: global_piqa_prompted_hrv_latn
+        languages: [hrv_Latn]
         subset: hrv_latn
       - task: global_piqa_prompted_hun_latn
+        languages: [hun_Latn]
         subset: hun_latn
       - task: global_piqa_prompted_isl_latn
+        languages: [isl_Latn]
         subset: isl_latn
       - task: global_piqa_prompted_ita_latn
+        languages: [ita_Latn]
         subset: ita_latn
       - task: global_piqa_prompted_kat_geor
+        languages: [kat_Geor]
         subset: kat_geor
       - task: global_piqa_prompted_lit_latn
+        languages: [lit_Latn]
         subset: lit_latn
       - task: global_piqa_prompted_mkd_cyrl
+        languages: [mkd_Cyrl]
         subset: mkd_cyrl
       - task: global_piqa_prompted_nld_latn
+        languages: [nld_Latn]
         subset: nld_latn
       - task: global_piqa_prompted_nno_latn
+        languages: [nno_Latn]
         subset: nno_latn
       - task: global_piqa_prompted_nob_latn
+        languages: [nob_Latn]
         subset: nob_latn
       - task: global_piqa_prompted_pol_latn
+        languages: [pol_Latn]
         subset: pol_latn
       - task: global_piqa_prompted_por_latn_port
+        languages: [por_Latn]
         subset: por_latn_port
       - task: global_piqa_prompted_ron_latn
+        languages: [ron_Latn]
         subset: ron_latn
       - task: global_piqa_prompted_slk_latn
+        languages: [slk_Latn]
         subset: slk_latn
       - task: global_piqa_prompted_slv_latn
+        languages: [slv_Latn]
         subset: slv_latn
       - task: global_piqa_prompted_spa_latn_spai
+        languages: [spa_Latn]
         subset: spa_latn_spai
       - task: global_piqa_prompted_srp_cyrl
+        languages: [srp_Cyrl]
         subset: srp_cyrl
       - task: global_piqa_prompted_swe_latn
+        languages: [swe_Latn]
         subset: swe_latn
       - task: global_piqa_prompted_tur_latn
+        languages: [tur_Latn]
         subset: tur_latn
       - task: global_piqa_prompted_ukr_cyrl
+        languages: [ukr_Cyrl]
         subset: ukr_cyrl
 
 super_groups:

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -18,6 +18,7 @@ class _Task:
     dataset: str | None = None
     subset: str | None = None
     suite: str | None = None
+    languages: list[str] | None = None
 
 
 @dataclass
@@ -55,6 +56,7 @@ class TaskGroup:
                     dataset=task_dataset,
                     subset=task_subset,
                     suite=task_data.get("suite"),
+                    languages=task_data.get("languages"),
                 )
             )
 
@@ -104,6 +106,46 @@ class TaskSuperGroup:
         )
 
 
+def _build_language_groups(
+    task_groups: dict[str, TaskGroup],
+) -> dict[str, TaskGroup]:
+    """Derive one virtual TaskGroup per language code from `languages` tags.
+
+    Every task tagged with a language (e.g. ``languages: [deu_Latn]``) is
+    collected into a synthetic group named after that code, so requesting
+    ``--task_groups "deu_Latn"`` yields all German tasks across all benchmarks.
+    Each task's suite is resolved from its origin group and baked onto the task,
+    so language groups can span lm-eval-harness and lighteval tasks at once.
+    """
+    buckets: dict[str, list[_Task]] = {}
+    for group in task_groups.values():
+        for t in group.tasks:
+            if not t.languages:
+                continue
+            resolved_suite = t.suite or group.suite
+            for lang in t.languages:
+                buckets.setdefault(lang, []).append(
+                    _Task(
+                        name=t.name,
+                        n_shots=t.n_shots,
+                        dataset=t.dataset,
+                        subset=t.subset,
+                        suite=resolved_suite,
+                        languages=t.languages,
+                    )
+                )
+
+    return {
+        lang: TaskGroup(
+            name=lang,
+            tasks=tasks,
+            suite="lm-eval-harness",  # fallback; each task carries its own suite
+            description=f"All evaluation tasks tagged with language '{lang}' (auto-derived)",
+        )
+        for lang, tasks in buckets.items()
+    }
+
+
 def _parse_task_groups(
     requested_groups: list[str],
 ) -> dict[str, TaskSuperGroup | TaskGroup]:
@@ -122,7 +164,11 @@ def _parse_task_groups(
             super_group_name, super_group_data, task_groups
         )
 
-    result = {**task_groups, **super_groups}
+    language_groups = _build_language_groups(task_groups)
+
+    # Explicit task groups / super groups take precedence over derived language
+    # groups on any name collision.
+    result = {**language_groups, **task_groups, **super_groups}
     return {
         group_name: group
         for group_name, group in result.items()
@@ -290,3 +336,15 @@ def get_all_task_group_names() -> list[str]:
         yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
     )
     return list(data.get("task_groups", {}).keys())
+
+
+def get_all_language_codes() -> list[str]:
+    """Return all language codes requestable as auto-derived task groups."""
+    data = (
+        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
+    )
+    task_groups = {
+        name: TaskGroup.from_dict(name, task_data)
+        for name, task_data in data.get("task_groups", {}).items()
+    }
+    return sorted(_build_language_groups(task_groups).keys())

--- a/scripts/tag_languages.py
+++ b/scripts/tag_languages.py
@@ -1,0 +1,190 @@
+"""Add `languages:` tags to multilingual tasks in task-groups.yaml.
+
+Each task in a known multilingual task group encodes its language in its
+`subset` (or task name), but across benchmarks the same language is spelled
+several ways (e.g. German is ``deu_Latn``, ``de``, ``German`` and ``deu_latn``).
+This script normalises all of those to a single canonical ``lang_Scri`` code
+(flores style) and inserts an explicit ``languages:`` list onto every task, so
+per-language task groups can be derived from a single source of truth.
+
+It uses only PyYAML (already a project dependency) to *read* the language of
+each task, then edits the file line-by-line so the diff is limited to the new
+``languages:`` lines and existing comments/formatting are untouched. No extra
+dependencies, runs against the prebuilt ``.venv``:
+
+    .venv/bin/python scripts/tag_languages.py            # write tags
+    .venv/bin/python scripts/tag_languages.py --check    # dry-run
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# Task groups whose tasks are language-specific and should be tagged.
+MULTILINGUAL_GROUPS = {
+    "sib200-eu",
+    "belebele-eu-5-shot",
+    "belebele-eu-cf",
+    "flores-200-eu-to-eng",
+    "flores-200-eng-to-eu",
+    "global-mmlu-eu",
+    "mgsm-eu",
+    "arc-challenge-mt-eu",
+    "include",
+    "global-piqa-eu-completions",
+    "global-piqa-eu-prompted",
+}
+
+# Map the various spellings used across benchmarks to the canonical lang_Scri code.
+ALIAS = {
+    # ISO 639-1 two-letter codes (global-mmlu, mgsm, arc-mt)
+    "de": "deu_Latn", "fr": "fra_Latn", "it": "ita_Latn", "es": "spa_Latn",
+    "pt": "por_Latn", "cs": "ces_Latn", "el": "ell_Grek", "lt": "lit_Latn",
+    "nl": "nld_Latn", "pl": "pol_Latn", "ro": "ron_Latn", "ru": "rus_Cyrl",
+    "sr": "srp_Cyrl", "sv": "swe_Latn", "tr": "tur_Latn", "uk": "ukr_Cyrl",
+    "he": "heb_Hebr", "en": "eng_Latn", "bg": "bul_Cyrl", "da": "dan_Latn",
+    "et": "est_Latn", "fi": "fin_Latn", "hu": "hun_Latn", "lv": "lvs_Latn",
+    "sk": "slk_Latn", "sl": "slv_Latn", "is": "isl_Latn", "nb": "nob_Latn",
+    # full English names (include)
+    "albanian": "als_Latn", "armenian": "hye_Armn", "azerbaijani": "aze_Latn",
+    "basque": "eus_Latn", "belarusian": "bel_Cyrl", "bulgarian": "bul_Cyrl",
+    "croatian": "hrv_Latn", "dutch": "nld_Latn", "estonian": "est_Latn",
+    "finnish": "fin_Latn", "french": "fra_Latn", "georgian": "kat_Geor",
+    "german": "deu_Latn", "greek": "ell_Grek", "hungarian": "hun_Latn",
+    "italian": "ita_Latn", "lithuanian": "lit_Latn",
+    "north macedonian": "mkd_Cyrl", "polish": "pol_Latn",
+    "portuguese": "por_Latn", "russian": "rus_Cyrl", "serbian": "srp_Cyrl",
+    "spanish": "spa_Latn", "turkish": "tur_Latn", "ukrainian": "ukr_Cyrl",
+}
+
+# Distinct individual-language codes that should fold into a macrolanguage code.
+SPECIAL = {"ekk_Latn": "est_Latn"}  # global-piqa uses ekk (Standard Estonian)
+
+DEFAULT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "oellm"
+    / "resources"
+    / "task-groups.yaml"
+)
+
+
+def canon(code: str) -> str | None:
+    """Normalise any spelling to a canonical ``lang_Scri`` code, or None."""
+    code = str(code).strip()
+    low = code.lower()
+    if low in ALIAS:
+        return ALIAS[low]
+    # lowercase ``lang_scri`` or ``lang_scri_region`` (global-piqa)
+    parts = low.split("_")
+    if len(parts) >= 2 and len(parts[0]) == 3 and len(parts[1]) == 4:
+        base = f"{parts[0]}_{parts[1].capitalize()}"
+        return SPECIAL.get(base, base)
+    # already canonical ``lang_Scri``
+    if re.match(r"^[a-z]{3}_[A-Z][a-z]{3}$", code):
+        return code
+    return None
+
+
+def flores_langs(task_name: str) -> list[str]:
+    """Non-English side(s) of a ``flores200:src-tgt`` pair."""
+    pair = task_name.split(":", 1)[1]
+    return [lang for lang in pair.split("-") if lang != "eng_Latn"]
+
+
+def resolve_languages(task: dict) -> list[str]:
+    """Determine the canonical language code(s) for a single task entry."""
+    name = task["task"]
+    if name.startswith("flores200:"):
+        return flores_langs(name)
+    src = task.get("subset")
+    if src is None:
+        # fall back to a trailing two-letter code in the task name (e.g. ``_is``)
+        m = re.search(r"_([a-z]{2})$", name)
+        src = m.group(1) if m else None
+    code = canon(src) if src is not None else None
+    return [code] if code else []
+
+
+def build_task_language_map(path: Path) -> tuple[dict[str, list[str]], list[tuple[str, str]]]:
+    """Map ``task name -> languages`` for all multilingual tasks, plus unresolved."""
+    data = yaml.safe_load(path.read_text()) or {}
+    mapping: dict[str, list[str]] = {}
+    unresolved: list[tuple[str, str]] = []
+    for gname in MULTILINGUAL_GROUPS:
+        for task in data["task_groups"][gname]["tasks"]:
+            langs = resolve_languages(task)
+            if langs:
+                mapping[task["task"]] = langs
+            else:
+                unresolved.append((gname, task["task"]))
+    return mapping, unresolved
+
+
+# Matches a task list item, capturing indentation and the task name. Names may
+# contain colons (``flores200:deu_Latn-eng_Latn``) or spaces
+# (``include_base_44_north macedonian``), so capture up to the last non-space.
+TASK_LINE = re.compile(r"^(?P<indent>\s*)- task:\s*(?P<name>.+?)\s*$")
+
+
+def insert_tags(path: Path, mapping: dict[str, list[str]]) -> tuple[int, str]:
+    """Insert a ``languages:`` line after each matching task line. Idempotent."""
+    lines = path.read_text().splitlines(keepends=True)
+    out: list[str] = []
+    inserted = 0
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        m = TASK_LINE.match(line.rstrip("\n"))
+        if m and m.group("name") in mapping:
+            key_indent = m.group("indent") + "  "
+            # Look ahead within this task block for an existing languages: key.
+            already = False
+            for nxt in lines[i + 1:]:
+                stripped = nxt.strip()
+                if not stripped:
+                    continue
+                # left the task block (dedent to dash or shallower)
+                cur_indent = len(nxt) - len(nxt.lstrip())
+                if cur_indent < len(key_indent):
+                    break
+                if stripped.startswith("- task:"):
+                    break
+                if stripped.startswith("languages:"):
+                    already = True
+                    break
+            if not already:
+                codes = ", ".join(mapping[m.group("name")])
+                out.append(f"{key_indent}languages: [{codes}]\n")
+                inserted += 1
+        i += 1
+    return inserted, "".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", type=Path, default=DEFAULT_PATH,
+                        help="Path to task-groups.yaml")
+    parser.add_argument("--check", action="store_true",
+                        help="Dry run: report counts without writing.")
+    args = parser.parse_args()
+
+    mapping, unresolved = build_task_language_map(args.path)
+    inserted, new_text = insert_tags(args.path, mapping)
+
+    if not args.check:
+        args.path.write_text(new_text)
+
+    verb = "Would insert" if args.check else "Inserted"
+    print(f"Resolved {len(mapping)} multilingual tasks; {verb} {inserted} languages: tags")
+    for group, task_name in unresolved:
+        print(f"UNRESOLVED: {group} / {task_name}")
+
+    return 1 if unresolved else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tag_languages.py
+++ b/scripts/tag_languages.py
@@ -41,33 +41,67 @@ MULTILINGUAL_GROUPS = {
 # Map the various spellings used across benchmarks to the canonical lang_Scri code.
 ALIAS = {
     # ISO 639-1 two-letter codes (global-mmlu, mgsm, arc-mt)
-    "de": "deu_Latn", "fr": "fra_Latn", "it": "ita_Latn", "es": "spa_Latn",
-    "pt": "por_Latn", "cs": "ces_Latn", "el": "ell_Grek", "lt": "lit_Latn",
-    "nl": "nld_Latn", "pl": "pol_Latn", "ro": "ron_Latn", "ru": "rus_Cyrl",
-    "sr": "srp_Cyrl", "sv": "swe_Latn", "tr": "tur_Latn", "uk": "ukr_Cyrl",
-    "he": "heb_Hebr", "en": "eng_Latn", "bg": "bul_Cyrl", "da": "dan_Latn",
-    "et": "est_Latn", "fi": "fin_Latn", "hu": "hun_Latn", "lv": "lvs_Latn",
-    "sk": "slk_Latn", "sl": "slv_Latn", "is": "isl_Latn", "nb": "nob_Latn",
+    "de": "deu_Latn",
+    "fr": "fra_Latn",
+    "it": "ita_Latn",
+    "es": "spa_Latn",
+    "pt": "por_Latn",
+    "cs": "ces_Latn",
+    "el": "ell_Grek",
+    "lt": "lit_Latn",
+    "nl": "nld_Latn",
+    "pl": "pol_Latn",
+    "ro": "ron_Latn",
+    "ru": "rus_Cyrl",
+    "sr": "srp_Cyrl",
+    "sv": "swe_Latn",
+    "tr": "tur_Latn",
+    "uk": "ukr_Cyrl",
+    "he": "heb_Hebr",
+    "en": "eng_Latn",
+    "bg": "bul_Cyrl",
+    "da": "dan_Latn",
+    "et": "est_Latn",
+    "fi": "fin_Latn",
+    "hu": "hun_Latn",
+    "lv": "lvs_Latn",
+    "sk": "slk_Latn",
+    "sl": "slv_Latn",
+    "is": "isl_Latn",
+    "nb": "nob_Latn",
     # full English names (include)
-    "albanian": "als_Latn", "armenian": "hye_Armn", "azerbaijani": "aze_Latn",
-    "basque": "eus_Latn", "belarusian": "bel_Cyrl", "bulgarian": "bul_Cyrl",
-    "croatian": "hrv_Latn", "dutch": "nld_Latn", "estonian": "est_Latn",
-    "finnish": "fin_Latn", "french": "fra_Latn", "georgian": "kat_Geor",
-    "german": "deu_Latn", "greek": "ell_Grek", "hungarian": "hun_Latn",
-    "italian": "ita_Latn", "lithuanian": "lit_Latn",
-    "north macedonian": "mkd_Cyrl", "polish": "pol_Latn",
-    "portuguese": "por_Latn", "russian": "rus_Cyrl", "serbian": "srp_Cyrl",
-    "spanish": "spa_Latn", "turkish": "tur_Latn", "ukrainian": "ukr_Cyrl",
+    "albanian": "als_Latn",
+    "armenian": "hye_Armn",
+    "azerbaijani": "aze_Latn",
+    "basque": "eus_Latn",
+    "belarusian": "bel_Cyrl",
+    "bulgarian": "bul_Cyrl",
+    "croatian": "hrv_Latn",
+    "dutch": "nld_Latn",
+    "estonian": "est_Latn",
+    "finnish": "fin_Latn",
+    "french": "fra_Latn",
+    "georgian": "kat_Geor",
+    "german": "deu_Latn",
+    "greek": "ell_Grek",
+    "hungarian": "hun_Latn",
+    "italian": "ita_Latn",
+    "lithuanian": "lit_Latn",
+    "north macedonian": "mkd_Cyrl",
+    "polish": "pol_Latn",
+    "portuguese": "por_Latn",
+    "russian": "rus_Cyrl",
+    "serbian": "srp_Cyrl",
+    "spanish": "spa_Latn",
+    "turkish": "tur_Latn",
+    "ukrainian": "ukr_Cyrl",
 }
 
 # Distinct individual-language codes that should fold into a macrolanguage code.
 SPECIAL = {"ekk_Latn": "est_Latn"}  # global-piqa uses ekk (Standard Estonian)
 
 DEFAULT_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "oellm"
-    / "resources"
-    / "task-groups.yaml"
+    Path(__file__).resolve().parent.parent / "oellm" / "resources" / "task-groups.yaml"
 )
 
 
@@ -108,7 +142,9 @@ def resolve_languages(task: dict) -> list[str]:
     return [code] if code else []
 
 
-def build_task_language_map(path: Path) -> tuple[dict[str, list[str]], list[tuple[str, str]]]:
+def build_task_language_map(
+    path: Path,
+) -> tuple[dict[str, list[str]], list[tuple[str, str]]]:
     """Map ``task name -> languages`` for all multilingual tasks, plus unresolved."""
     data = yaml.safe_load(path.read_text()) or {}
     mapping: dict[str, list[str]] = {}
@@ -143,7 +179,7 @@ def insert_tags(path: Path, mapping: dict[str, list[str]]) -> tuple[int, str]:
             key_indent = m.group("indent") + "  "
             # Look ahead within this task block for an existing languages: key.
             already = False
-            for nxt in lines[i + 1:]:
+            for nxt in lines[i + 1 :]:
                 stripped = nxt.strip()
                 if not stripped:
                     continue
@@ -166,10 +202,12 @@ def insert_tags(path: Path, mapping: dict[str, list[str]]) -> tuple[int, str]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--path", type=Path, default=DEFAULT_PATH,
-                        help="Path to task-groups.yaml")
-    parser.add_argument("--check", action="store_true",
-                        help="Dry run: report counts without writing.")
+    parser.add_argument(
+        "--path", type=Path, default=DEFAULT_PATH, help="Path to task-groups.yaml"
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="Dry run: report counts without writing."
+    )
     args = parser.parse_args()
 
     mapping, unresolved = build_task_language_map(args.path)
@@ -179,7 +217,9 @@ def main() -> int:
         args.path.write_text(new_text)
 
     verb = "Would insert" if args.check else "Inserted"
-    print(f"Resolved {len(mapping)} multilingual tasks; {verb} {inserted} languages: tags")
+    print(
+        f"Resolved {len(mapping)} multilingual tasks; {verb} {inserted} languages: tags"
+    )
     for group, task_name in unresolved:
         print(f"UNRESOLVED: {group} / {task_name}")
 

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -1,0 +1,77 @@
+"""Tests for auto-derived per-language task groups (e.g. --task_groups deu_Latn)."""
+
+from importlib.resources import files
+
+import pytest
+import yaml
+
+from oellm.task_groups import (
+    _collect_dataset_specs,
+    _expand_task_groups,
+    get_all_language_codes,
+)
+
+# Groups whose tasks are language-specific and must therefore all carry a
+# `languages:` tag. Keep in sync with scripts/tag_languages.py.
+MULTILINGUAL_GROUPS = {
+    "sib200-eu",
+    "belebele-eu-5-shot",
+    "belebele-eu-cf",
+    "flores-200-eu-to-eng",
+    "flores-200-eng-to-eu",
+    "global-mmlu-eu",
+    "mgsm-eu",
+    "arc-challenge-mt-eu",
+    "include",
+    "global-piqa-eu-completions",
+    "global-piqa-eu-prompted",
+}
+
+
+def _load_yaml() -> dict:
+    return (
+        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
+    )
+
+
+@pytest.mark.parametrize("group_name", sorted(MULTILINGUAL_GROUPS))
+def test_every_multilingual_task_is_tagged(group_name):
+    """Every task in a multilingual group must carry a `languages` tag, so that
+    coverage of the derived language groups cannot silently regress."""
+    group = _load_yaml()["task_groups"][group_name]
+    untagged = [t["task"] for t in group["tasks"] if not t.get("languages")]
+    assert not untagged, f"{group_name} has untagged tasks: {untagged}"
+
+
+def test_language_codes_available():
+    codes = get_all_language_codes()
+    assert len(codes) >= 30
+    for expected in ["deu_Latn", "fra_Latn", "ita_Latn", "spa_Latn", "por_Latn"]:
+        assert expected in codes
+
+
+def test_language_group_expands_and_mixes_suites():
+    jobs = _expand_task_groups(["deu_Latn"])
+    assert len(jobs) >= 10
+    # German spans both evaluation suites (belebele-cf + flores are lighteval).
+    suites = {j.suite for j in jobs}
+    assert "lm-eval-harness" in suites
+    assert "lighteval" in suites
+    # n_shot must be resolved to ints for every job.
+    assert all(isinstance(j.n_shot, int) for j in jobs)
+
+
+def test_mgsm_gap_is_handled():
+    """Italian/Portuguese lack mgsm; their groups should still resolve (no crash)
+    and simply omit the mgsm task rather than fail."""
+    for lang in ["ita_Latn", "por_Latn"]:
+        tasks = {j.task for j in _expand_task_groups([lang])}
+        assert tasks
+        assert not any(t.startswith("mgsm") for t in tasks)
+
+
+def test_language_group_collects_dataset_specs():
+    specs = _collect_dataset_specs(["deu_Latn"])
+    assert specs
+    repos = {s.repo_id for s in specs}
+    assert "facebook/belebele" in repos


### PR DESCRIPTION
Adds a `languages:` field to every task in the multilingual task groups and derives a virtual task group per language code from those tags. You can now run every available eval for a language with one canonical `lang_Script` code:
  
  ```bash
  oellm-eval schedule --models my-datamix-model --task_groups deu_Latn
  oellm-eval schedule --models my-model --task_groups "fra_Latn,ita_Latn,por_Latn"
```
  - scripts/tag_languages.py — re-runnable, comment-preserving tagger (PyYAML only, no new deps). Tag a new benchmark once and it flows into the relevant language groups automatically.

 _Notes / follow-ups (not in this PR)_

  - mgsm gap: ita_Latn/por_Latn lack a GSM math eval — MGSM (jbross-ibm-research/mgsm) simply has no it/pt configs, so the gap is intrinsic to the benchmark, not a missing tag. (It does have unused ca/eu/gl  that could enrich those language groups happy to add in a follow-up.)
  - generic-multilingual (xwinograd/xcopa/xstorycloze) is left untagged since it isn't language-split in the registry.

[Issue Reference](https://github.com/OpenEuroLLM/oellm-evals/issues/78)