### PR TITLE
feat: filter eval tasks by language (per-group [lang] brackets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ oellm-eval schedule --models "my-model" \
 oellm-eval schedule --models "my-model" --task_groups "sib200-eu"
 ```
 
+For different languages per benchmark, attach a `[...]` bracket to a task group.
+The bracketed codes (separated by `,` or `|`) override the global `--languages`
+filter for that group only:
+
+```bash
+# French SIB-200 *and* German FLORES in one run.
+oellm-eval schedule --models "my-model" \
+    --task_groups "sib200-eu[fra_Latn],flores-200-eu-to-eng[deu_Latn]"
+
+# Multiple languages inside one bracket.
+oellm-eval schedule --models "my-model" --task_groups "sib200-eu[fra_Latn|deu_Latn]"
+```
+
 Each task's language is derived in code from the `{lang}` value of a
 `valid_langs` template, or the task's `subset` for explicitly-listed
 multilingual groups (see [docs/TASKS.md](docs/TASKS.md)). No per-task tagging is
@@ -110,6 +123,8 @@ Notes:
 - A **partial** match (some requested languages absent from the selected
   groups) warns and proceeds with the rest. Some languages simply lack certain
   benchmarks (e.g. Italian/Portuguese have no MGSM).
+- A per-group `[...]` bracket is stricter: if it matches nothing in *its* group
+  it errors (the request was explicit, so an empty result is a mistake).
 
 ## Running Locally (without SLURM)
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ filterable automatically.
 
 Notes:
 
-- Codes accept common spellings (`de`, `german`, `deu_Latn`) and are folded to
-  the canonical `lang_Script` form.
+- Use the precise canonical `lang_Scri` code (e.g. `deu_Latn`). Looser
+  spellings such as `de` or `german` are rejected; if you pass one, the error
+  names the canonical code to use instead.
 - An **unknown** code (typo) errors and lists the valid codes.
 - A bracket that matches **no task** in its group (e.g.
   `flores-200-eu-to-eng[ukr_Cyrl]`, since FLORES-EU has no Ukrainian) errors

--- a/README.md
+++ b/README.md
@@ -67,29 +67,49 @@ oellm-eval schedule --models "model-name" --task_groups "belebele-eu-5-shot,glob
 oellm-eval schedule --models "model-name" --task_groups "oellm-multilingual"
 ```
 
-### Per-language task groups
+### Filtering by language
 
-A task group is automatically derived for each language, letting you run *every*
-available evaluation for one language with a single canonical
-[`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag) code:
+`--languages` filters tasks by language, using canonical
+[`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag) codes (e.g.
+`deu_Latn`, `fra_Latn`). It is a separate axis from `--task_groups`:
+`--task_groups` chooses *which benchmarks*, `--languages` chooses *which
+languages*. They compose in three ways:
 
 ```bash
-# All German evaluations (SIB-200, Belebele MC+CF, Global-MMLU, ARC-MT,
-# Global-PIQA, INCLUDE, MGSM, FLORES, …)
-oellm-eval schedule --models "my-model" --task_groups "deu_Latn"
+# Languages only: every available evaluation for German across all benchmarks
+# (SIB-200, Belebele MC+CF, Global-MMLU, ARC-MT, Global-PIQA, INCLUDE, MGSM,
+# FLORES, …) — spanning both lm-eval-harness and lighteval.
+oellm-eval schedule --models "my-model" --languages "deu_Latn"
 
-# Several monolingual models against their own language
-oellm-eval schedule --models "model" --task_groups "fra_Latn,ita_Latn,por_Latn"
+# Several monolingual models, each against its own language.
+oellm-eval schedule --models "model" --languages "fra_Latn,ita_Latn,por_Latn"
+
+# Task groups + languages: the intersection — only the German tasks within
+# those two benchmarks.
+oellm-eval schedule --models "my-model" \
+    --task_groups "sib200-eu,global-mmlu-eu" --languages "deu_Latn"
+
+# Task groups only: unchanged — all languages in the group.
+oellm-eval schedule --models "my-model" --task_groups "sib200-eu"
 ```
 
-These groups are derived in code from each task's language: the `{lang}` value
-of a `valid_langs` template, or the task's `subset` for explicitly-listed
+Each task's language is derived in code from the `{lang}` value of a
+`valid_langs` template, or the task's `subset` for explicitly-listed
 multilingual groups (see [docs/TASKS.md](docs/TASKS.md)). No per-task tagging is
 needed — adding a benchmark with a `valid_langs` template makes its languages
-available as groups automatically. A language group transparently spans both
-`lm-eval-harness` and `lighteval` tasks. Some languages lack certain benchmarks
-(e.g. Italian/Portuguese have no MGSM), in which case the group simply contains
-fewer tasks.
+filterable automatically.
+
+Notes:
+
+- Codes accept common spellings (`de`, `german`, `deu_Latn`) and are folded to
+  the canonical `lang_Script` form.
+- An **unknown** code (typo) errors and lists the valid codes.
+- A **fully empty** intersection (e.g. `--task_groups flores-200-eu-to-eng
+  --languages ukr_Cyrl`, since FLORES-EU has no Ukrainian) errors rather than
+  silently scheduling nothing.
+- A **partial** match (some requested languages absent from the selected
+  groups) warns and proceeds with the rest. Some languages simply lack certain
+  benchmarks (e.g. Italian/Portuguese have no MGSM).
 
 ## Running Locally (without SLURM)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ oellm-eval schedule --models "model-name" --task_groups "belebele-eu-5-shot,glob
 oellm-eval schedule --models "model-name" --task_groups "oellm-multilingual"
 ```
 
+### Per-language task groups
+
+A task group is automatically derived for each language, letting you run *every*
+available evaluation for one language with a single canonical
+[`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag) code:
+
+```bash
+# All German evaluations (SIB-200, Belebele MC+CF, Global-MMLU, ARC-MT,
+# Global-PIQA, INCLUDE, MGSM, FLORES, …)
+oellm-eval schedule --models "my-model" --task_groups "deu_Latn"
+
+# Several monolingual models against their own language
+oellm-eval schedule --models "model" --task_groups "fra_Latn,ita_Latn,por_Latn"
+```
+
+These groups are derived in code from each task's language: the `{lang}` value
+of a `valid_langs` template, or the task's `subset` for explicitly-listed
+multilingual groups (see [docs/TASKS.md](docs/TASKS.md)). No per-task tagging is
+needed — adding a benchmark with a `valid_langs` template makes its languages
+available as groups automatically. A language group transparently spans both
+`lm-eval-harness` and `lighteval` tasks. Some languages lack certain benchmarks
+(e.g. Italian/Portuguese have no MGSM), in which case the group simply contains
+fewer tasks.
+
 ## Running Locally (without SLURM)
 
 The `--local` flag lets you run evaluations directly on your machine without a cluster or Singularity container. It generates the same eval script and executes it with bash, injecting fake SLURM environment variables so all tasks run sequentially in a single process. This is useful for testing that tasks and models are correctly configured before submitting to a cluster.

--- a/README.md
+++ b/README.md
@@ -69,41 +69,35 @@ oellm-eval schedule --models "model-name" --task_groups "oellm-multilingual"
 
 ### Filtering by language
 
-`--languages` filters tasks by language, using canonical
+Scope a task group (or super group) to one or more languages by attaching a
+`[...]` bracket to its name. Languages use canonical
 [`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag) codes (e.g.
-`deu_Latn`, `fra_Latn`). It is a separate axis from `--task_groups`:
-`--task_groups` chooses *which benchmarks*, `--languages` chooses *which
-languages*. They compose in three ways:
+`deu_Latn`, `fra_Latn`); codes inside a bracket may be separated by `,` or `|`.
 
 ```bash
-# Languages only: every available evaluation for German across all benchmarks
-# (SIB-200, Belebele MC+CF, Global-MMLU, ARC-MT, Global-PIQA, INCLUDE, MGSM,
-# FLORES, …) — spanning both lm-eval-harness and lighteval.
-oellm-eval schedule --models "my-model" --languages "deu_Latn"
+# The applicable subset of the multilingual super group for one language —
+# the simplest way to evaluate a monolingual model on its language across
+# every multilingual benchmark (FLORES, Belebele, Global-MMLU, INCLUDE, MGSM,
+# …), spanning both lm-eval-harness and lighteval.
+oellm-eval schedule --models "my-model" --task_groups "oellm-multilingual[deu_Latn]"
 
-# Several monolingual models, each against its own language.
-oellm-eval schedule --models "model" --languages "fra_Latn,ita_Latn,por_Latn"
+# Every benchmark in the registry for one language. `all` is an auto-generated
+# super group (always spans every task group, no hand-maintenance) — use it for
+# the complete per-language set rather than the curated `oellm-multilingual`.
+oellm-eval schedule --models "my-model" --task_groups "all[deu_Latn]"
 
-# Task groups + languages: the intersection — only the German tasks within
-# those two benchmarks.
-oellm-eval schedule --models "my-model" \
-    --task_groups "sib200-eu,global-mmlu-eu" --languages "deu_Latn"
-
-# Task groups only: unchanged — all languages in the group.
-oellm-eval schedule --models "my-model" --task_groups "sib200-eu"
-```
-
-For different languages per benchmark, attach a `[...]` bracket to a task group.
-The bracketed codes (separated by `,` or `|`) override the global `--languages`
-filter for that group only:
-
-```bash
-# French SIB-200 *and* German FLORES in one run.
-oellm-eval schedule --models "my-model" \
-    --task_groups "sib200-eu[fra_Latn],flores-200-eu-to-eng[deu_Latn]"
+# A single benchmark, scoped to German.
+oellm-eval schedule --models "my-model" --task_groups "sib200-eu[deu_Latn]"
 
 # Multiple languages inside one bracket.
 oellm-eval schedule --models "my-model" --task_groups "sib200-eu[fra_Latn|deu_Latn]"
+
+# Different languages per benchmark in one run — French SIB-200 *and* German FLORES.
+oellm-eval schedule --models "my-model" \
+    --task_groups "sib200-eu[fra_Latn],flores-200-eu-to-eng[deu_Latn]"
+
+# No bracket: the group is unchanged — all of its languages.
+oellm-eval schedule --models "my-model" --task_groups "sib200-eu"
 ```
 
 Each task's language is derived in code from the `{lang}` value of a
@@ -117,14 +111,13 @@ Notes:
 - Codes accept common spellings (`de`, `german`, `deu_Latn`) and are folded to
   the canonical `lang_Script` form.
 - An **unknown** code (typo) errors and lists the valid codes.
-- A **fully empty** intersection (e.g. `--task_groups flores-200-eu-to-eng
-  --languages ukr_Cyrl`, since FLORES-EU has no Ukrainian) errors rather than
-  silently scheduling nothing.
-- A **partial** match (some requested languages absent from the selected
-  groups) warns and proceeds with the rest. Some languages simply lack certain
-  benchmarks (e.g. Italian/Portuguese have no MGSM).
-- A per-group `[...]` bracket is stricter: if it matches nothing in *its* group
-  it errors (the request was explicit, so an empty result is a mistake).
+- A bracket that matches **no task** in its group (e.g.
+  `flores-200-eu-to-eng[ukr_Cyrl]`, since FLORES-EU has no Ukrainian) errors
+  rather than silently scheduling nothing.
+- When a bracket lists several languages and only **some** are present in the
+  group, it keeps the matches and warns about the rest. Some languages simply
+  lack certain benchmarks (e.g. Italian/Portuguese have no MGSM), so a super
+  group bracket transparently omits the missing ones.
 
 ## Running Locally (without SLURM)
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -73,6 +73,12 @@ oellm-eval schedule --models "m" \
     --task_groups "sib200-eu[fra_Latn],flores-200-eu-to-eng[deu_Latn]"
 ```
 
+Inside the bracket, use the precise canonical `lang_Scri` code (e.g.
+`deu_Latn`). Looser spellings such as `de` or `german` are **not** accepted as
+input — they are rejected with an error naming the canonical code. (The folding
+described below applies only to the benchmarks' own internal spellings when
+deriving a task's language, not to what you type in the bracket.)
+
 Languages are **derived in code** — there is no `languages` field to set in the
 YAML. A task resolves to a canonical [`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag)
 code (e.g. `deu_Latn`) from, in order:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -55,6 +55,44 @@ oellm-eval schedule --models "model-name" --task_groups "my-benchmark"
 | `task` | Yes | task | Task name as recognized by the evaluation suite |
 | `subset` | No | task | HuggingFace dataset config/subset name |
 
+## Language filtering (`--languages`)
+
+Tasks can be filtered by language with `--languages`, independently of which
+groups are selected:
+
+```bash
+# All German tasks across every benchmark
+oellm-eval schedule --models "m" --languages "deu_Latn"
+
+# Intersection: only German tasks within these benchmarks
+oellm-eval schedule --models "m" --task_groups "sib200-eu" --languages "deu_Latn"
+```
+
+Languages are **derived in code** — there is no `languages` field to set in the
+YAML. A task resolves to a canonical [`lang_Script`](https://en.wikipedia.org/wiki/IETF_language_tag)
+code (e.g. `deu_Latn`) from, in order:
+
+1. **`flores200:src-tgt` task names** → the non-English side(s) of the pair.
+2. **The `{lang}` value** substituted into a `valid_langs` template (preferred
+   for new multilingual groups — see the template expansion above).
+3. **The task's `subset`** (e.g. `de`, `german`, `deu_Latn` all fold to
+   `deu_Latn`).
+4. A **trailing language code in the task name** (e.g. `arc_challenge_mt_de`),
+   used only when no `subset` is given.
+
+The normaliser (`oellm/task_groups.py`) folds the many spellings benchmarks use
+(`de` / `deu_Latn` / `German` / `deu_latn`) onto one canonical code. To make a
+new benchmark's languages filterable, prefer a `valid_langs` template or a
+language-coded `subset`; if you introduce a spelling the normaliser doesn't yet
+recognise, add it to `_LANG_ALIAS`. The guard test
+`tests/test_language_groups.py::test_templated_tasks_all_resolve_to_a_language`
+fails if any task in a templated or multilingual group does not resolve to a
+language.
+
+A single language filter transparently spans both `lm-eval-harness` and
+`lighteval` tasks, since each task carries its own resolved suite. Unknown codes
+error; a fully empty intersection errors; a partial match warns and proceeds.
+
 ## Important: Dataset Requirement
 
 **You must provide the `dataset` field** (at group or task level) for:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -55,21 +55,20 @@ oellm-eval schedule --models "model-name" --task_groups "my-benchmark"
 | `task` | Yes | task | Task name as recognized by the evaluation suite |
 | `subset` | No | task | HuggingFace dataset config/subset name |
 
-## Language filtering (`--languages`)
+## Language filtering (`group[lang]` brackets)
 
-Tasks can be filtered by language with `--languages`, independently of which
-groups are selected:
+Scope a task group (or super group) to one or more languages by attaching a
+`[...]` bracket to its name. Codes inside the bracket may be separated by `,`
+or `|`:
 
 ```bash
-# All German tasks across every benchmark
-oellm-eval schedule --models "m" --languages "deu_Latn"
+# The applicable subset of the multilingual super group, for one language
+oellm-eval schedule --models "m" --task_groups "oellm-multilingual[deu_Latn]"
 
-# Intersection: only German tasks within these benchmarks
-oellm-eval schedule --models "m" --task_groups "sib200-eu" --languages "deu_Latn"
+# A single benchmark, scoped to German
+oellm-eval schedule --models "m" --task_groups "sib200-eu[deu_Latn]"
 
-# Per-group override: different language per benchmark, via a [...] bracket
-# (codes separated by `,` or `|`). The bracket overrides --languages for that
-# group, and errors if it matches nothing in that group.
+# Different language per benchmark in one run
 oellm-eval schedule --models "m" \
     --task_groups "sib200-eu[fra_Latn],flores-200-eu-to-eng[deu_Latn]"
 ```
@@ -95,9 +94,11 @@ recognise, add it to `_LANG_ALIAS`. The guard test
 fails if any task in a templated or multilingual group does not resolve to a
 language.
 
-A single language filter transparently spans both `lm-eval-harness` and
-`lighteval` tasks, since each task carries its own resolved suite. Unknown codes
-error; a fully empty intersection errors; a partial match warns and proceeds.
+A language bracket transparently spans both `lm-eval-harness` and `lighteval`
+tasks, since each task carries its own resolved suite. Unknown codes error; a
+bracket that matches no task in its group errors; when a bracket lists several
+languages and only some are present, the matches are kept and the rest warned
+about (some languages simply lack certain benchmarks).
 
 ## Important: Dataset Requirement
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -66,6 +66,12 @@ oellm-eval schedule --models "m" --languages "deu_Latn"
 
 # Intersection: only German tasks within these benchmarks
 oellm-eval schedule --models "m" --task_groups "sib200-eu" --languages "deu_Latn"
+
+# Per-group override: different language per benchmark, via a [...] bracket
+# (codes separated by `,` or `|`). The bracket overrides --languages for that
+# group, and errors if it matches nothing in that group.
+oellm-eval schedule --models "m" \
+    --task_groups "sib200-eu[fra_Latn],flores-200-eu-to-eng[deu_Latn]"
 ```
 
 Languages are **derived in code** — there is no `languages` field to set in the

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -106,7 +106,6 @@ def schedule_evals(
     models: str | None = None,
     tasks: str | None = None,
     task_groups: str | None = None,
-    languages: str | None = None,
     n_shot: int | list[int] | None = None,
     eval_csv_path: str | None = None,
     *,
@@ -139,13 +138,11 @@ def schedule_evals(
             Requires `n_shot` to be provided. Tasks here are assumed to be lm_eval unless otherwise handled via CSV.
         task_groups: A string of comma-separated task group names defined in `task-groups.yaml`.
             Each group expands into concrete (task, n_shots, suite) entries; `n_shot` is ignored for groups.
-        languages: A string of comma-separated language codes (e.g. `deu_Latn,fra_Latn`) used to
-            filter tasks by language. With `task_groups`, keeps only matching-language tasks within
-            those groups (intersection). Without `task_groups`, selects all matching-language tasks
-            across every benchmark. Unknown codes raise; an entirely empty intersection raises, while
-            a partial match warns and proceeds. A per-group override may be given as a bracket on a
-            task group, e.g. `--task_groups "sib200-eu[fra_Latn],flores200[deu_Latn]"`, where the
-            bracketed codes (separated by `,` or `|`) replace this global filter for that group.
+            A group (or super_group) may be scoped to one or more languages with a bracket, e.g.
+            `--task_groups "oellm-multilingual[deu_Latn]"` or
+            `--task_groups "sib200-eu[fra_Latn|deu_Latn],flores200[deu_Latn]"`. Bracketed codes are
+            separated by `,` or `|`; unknown codes raise, and a bracket that matches no task in its
+            group raises.
         n_shot: An integer or list of integers specifying the number of shots applied to `tasks`.
         eval_csv_path: A path to a CSV file containing evaluation data.
             Warning: exclusive argument. Cannot specify `models`, `tasks`, `task_groups`, or `n_shot` when `eval_csv_path` is provided.
@@ -213,9 +210,9 @@ def schedule_evals(
 
     eval_jobs: list[EvaluationJob] = []
     if eval_csv_path:
-        if models or tasks or task_groups or languages or n_shot:
+        if models or tasks or task_groups or n_shot:
             raise ValueError(
-                "Cannot specify `models`, `tasks`, `task_groups`, `languages`, or `n_shot` when `eval_csv_path` is provided."
+                "Cannot specify `models`, `tasks`, `task_groups`, or `n_shot` when `eval_csv_path` is provided."
             )
         df = pd.read_csv(eval_csv_path)
         required_cols = {"model_path", "task_path", "n_shot"}
@@ -244,7 +241,7 @@ def schedule_evals(
         )
 
     elif models:
-        if task_groups is None and languages is None:
+        if task_groups is None:
             task_suite_map = _build_task_suite_map()
             eval_jobs.extend(
                 [
@@ -261,10 +258,7 @@ def schedule_evals(
             )
         else:
             group_list = split_group_tokens(task_groups) if task_groups else []
-            lang_list = (
-                [lang.strip() for lang in languages.split(",")] if languages else None
-            )
-            expanded = _expand_task_groups(group_list, languages=lang_list)
+            expanded = _expand_task_groups(group_list)
             eval_jobs.extend(
                 [
                     EvaluationJob(
@@ -318,12 +312,9 @@ def schedule_evals(
     # network access on compute nodes.
     if not skip_checks:
         dataset_specs = []
-        if task_groups or languages:
-            group_list = split_group_tokens(task_groups) if task_groups else []
-            lang_list = (
-                [lang.strip() for lang in languages.split(",")] if languages else None
-            )
-            dataset_specs = _collect_dataset_specs(group_list, languages=lang_list)
+        if task_groups:
+            group_list = split_group_tokens(task_groups)
+            dataset_specs = _collect_dataset_specs(group_list)
         else:
             # Look up individual tasks in task groups registry
             all_tasks = df["task_path"].unique().tolist()

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -18,6 +18,7 @@ from oellm.task_groups import (
     _collect_dataset_specs,
     _expand_task_groups,
     _lookup_dataset_specs_for_tasks,
+    split_group_tokens,
 )
 from oellm.utils import (
     _ensure_runtime_environment,
@@ -142,7 +143,9 @@ def schedule_evals(
             filter tasks by language. With `task_groups`, keeps only matching-language tasks within
             those groups (intersection). Without `task_groups`, selects all matching-language tasks
             across every benchmark. Unknown codes raise; an entirely empty intersection raises, while
-            a partial match warns and proceeds.
+            a partial match warns and proceeds. A per-group override may be given as a bracket on a
+            task group, e.g. `--task_groups "sib200-eu[fra_Latn],flores200[deu_Latn]"`, where the
+            bracketed codes (separated by `,` or `|`) replace this global filter for that group.
         n_shot: An integer or list of integers specifying the number of shots applied to `tasks`.
         eval_csv_path: A path to a CSV file containing evaluation data.
             Warning: exclusive argument. Cannot specify `models`, `tasks`, `task_groups`, or `n_shot` when `eval_csv_path` is provided.
@@ -257,9 +260,7 @@ def schedule_evals(
                 ]
             )
         else:
-            group_list = (
-                [g.strip() for g in task_groups.split(",")] if task_groups else []
-            )
+            group_list = split_group_tokens(task_groups) if task_groups else []
             lang_list = (
                 [lang.strip() for lang in languages.split(",")] if languages else None
             )
@@ -318,9 +319,7 @@ def schedule_evals(
     if not skip_checks:
         dataset_specs = []
         if task_groups or languages:
-            group_list = (
-                [g.strip() for g in task_groups.split(",")] if task_groups else []
-            )
+            group_list = split_group_tokens(task_groups) if task_groups else []
             lang_list = (
                 [lang.strip() for lang in languages.split(",")] if languages else None
             )

--- a/oellm/main.py
+++ b/oellm/main.py
@@ -105,6 +105,7 @@ def schedule_evals(
     models: str | None = None,
     tasks: str | None = None,
     task_groups: str | None = None,
+    languages: str | None = None,
     n_shot: int | list[int] | None = None,
     eval_csv_path: str | None = None,
     *,
@@ -137,6 +138,11 @@ def schedule_evals(
             Requires `n_shot` to be provided. Tasks here are assumed to be lm_eval unless otherwise handled via CSV.
         task_groups: A string of comma-separated task group names defined in `task-groups.yaml`.
             Each group expands into concrete (task, n_shots, suite) entries; `n_shot` is ignored for groups.
+        languages: A string of comma-separated language codes (e.g. `deu_Latn,fra_Latn`) used to
+            filter tasks by language. With `task_groups`, keeps only matching-language tasks within
+            those groups (intersection). Without `task_groups`, selects all matching-language tasks
+            across every benchmark. Unknown codes raise; an entirely empty intersection raises, while
+            a partial match warns and proceeds.
         n_shot: An integer or list of integers specifying the number of shots applied to `tasks`.
         eval_csv_path: A path to a CSV file containing evaluation data.
             Warning: exclusive argument. Cannot specify `models`, `tasks`, `task_groups`, or `n_shot` when `eval_csv_path` is provided.
@@ -204,9 +210,9 @@ def schedule_evals(
 
     eval_jobs: list[EvaluationJob] = []
     if eval_csv_path:
-        if models or tasks or task_groups or n_shot:
+        if models or tasks or task_groups or languages or n_shot:
             raise ValueError(
-                "Cannot specify `models`, `tasks`, `task_groups`, or `n_shot` when `eval_csv_path` is provided."
+                "Cannot specify `models`, `tasks`, `task_groups`, `languages`, or `n_shot` when `eval_csv_path` is provided."
             )
         df = pd.read_csv(eval_csv_path)
         required_cols = {"model_path", "task_path", "n_shot"}
@@ -235,7 +241,7 @@ def schedule_evals(
         )
 
     elif models:
-        if task_groups is None:
+        if task_groups is None and languages is None:
             task_suite_map = _build_task_suite_map()
             eval_jobs.extend(
                 [
@@ -251,7 +257,13 @@ def schedule_evals(
                 ]
             )
         else:
-            expanded = _expand_task_groups([g.strip() for g in task_groups.split(",")])
+            group_list = (
+                [g.strip() for g in task_groups.split(",")] if task_groups else []
+            )
+            lang_list = (
+                [lang.strip() for lang in languages.split(",")] if languages else None
+            )
+            expanded = _expand_task_groups(group_list, languages=lang_list)
             eval_jobs.extend(
                 [
                     EvaluationJob(
@@ -305,10 +317,14 @@ def schedule_evals(
     # network access on compute nodes.
     if not skip_checks:
         dataset_specs = []
-        if task_groups:
-            dataset_specs = _collect_dataset_specs(
-                [g.strip() for g in task_groups.split(",")]
+        if task_groups or languages:
+            group_list = (
+                [g.strip() for g in task_groups.split(",")] if task_groups else []
             )
+            lang_list = (
+                [lang.strip() for lang in languages.split(",")] if languages else None
+            )
+            dataset_specs = _collect_dataset_specs(group_list, languages=lang_list)
         else:
             # Look up individual tasks in task groups registry
             all_tasks = df["task_path"].unique().tolist()

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -10,7 +11,7 @@ import yaml
 # Tasks encode their language in several incompatible ways across benchmarks
 # (e.g. German is ``deu_Latn``, ``de``, ``German`` and ``deu_latn``). These
 # tables fold every spelling onto a single canonical ``lang_Scri`` code so that
-# per-language task groups (e.g. ``--task_groups deu_Latn``) can be derived.
+# the ``--languages deu_Latn`` filter can match tasks across benchmarks.
 _LANG_ALIAS = {
     # ISO 639-1 two-letter codes (global-mmlu, mgsm, arc-mt)
     "de": "deu_Latn",
@@ -258,41 +259,18 @@ def _load_task_groups_data() -> dict:
     return _expand_lang_templates(raw)
 
 
-def _build_language_groups(
-    task_groups: dict[str, TaskGroup],
-) -> dict[str, TaskGroup]:
-    """Derive one virtual TaskGroup per language code.
+def _language_codes_from_groups(task_groups: dict[str, TaskGroup]) -> set[str]:
+    """Collect every canonical language code that at least one task resolves to.
 
-    Every task that resolves to a language (via its ``{lang}`` template
-    expansion or ``subset``) is collected into a synthetic group named after
-    that canonical code, so ``--task_groups deu_Latn`` yields all German tasks
-    across all benchmarks. Each task's suite is resolved from its origin group
-    and baked on, so a language group can span lm-eval-harness and lighteval.
+    These are the codes accepted by the ``--languages`` filter; a task resolves
+    to a code via its ``{lang}`` template expansion or its ``subset`` (see
+    ``_resolve_task_languages``).
     """
-    buckets: dict[str, list[_Task]] = {}
-    for group in task_groups.values():
-        for t in group.tasks:
-            resolved_suite = t.suite or group.suite
-            for lang in t.languages:
-                buckets.setdefault(lang, []).append(
-                    _Task(
-                        name=t.name,
-                        n_shots=t.n_shots,
-                        dataset=t.dataset,
-                        subset=t.subset,
-                        suite=resolved_suite,
-                        languages=t.languages,
-                    )
-                )
-
     return {
-        lang: TaskGroup(
-            name=lang,
-            tasks=tasks,
-            suite="lm-eval-harness",  # fallback; each task carries its own suite
-            description=f"All evaluation tasks for language '{lang}' (auto-derived)",
-        )
-        for lang, tasks in buckets.items()
+        lang
+        for group in task_groups.values()
+        for t in group.tasks
+        for lang in t.languages
     }
 
 
@@ -312,11 +290,7 @@ def _parse_task_groups(
             super_group_name, super_group_data, task_groups
         )
 
-    language_groups = _build_language_groups(task_groups)
-
-    # Explicit task groups / super groups take precedence over derived language
-    # groups on any name collision.
-    result = {**language_groups, **task_groups, **super_groups}
+    result = {**task_groups, **super_groups}
     return {
         group_name: group
         for group_name, group in result.items()
@@ -331,34 +305,119 @@ class TaskGroupResult:
     suite: str
 
 
-def _expand_task_groups(group_names: Iterable[str]) -> list[TaskGroupResult]:
-    parsed = _parse_task_groups([str(n).strip() for n in group_names if str(n).strip()])
-    missing = {str(n).strip() for n in group_names if str(n).strip()} - set(parsed.keys())
+def _iter_group_tasks(
+    parsed: dict[str, "TaskSuperGroup | TaskGroup"],
+) -> Iterable[tuple[str, _Task]]:
+    """Yield ``(resolved_suite, task)`` for every task in the parsed groups.
+
+    Flattens both plain task groups and super groups, resolving each task's
+    suite from its explicit ``suite`` or the owning group's default.
+    """
+    for group in parsed.values():
+        if isinstance(group, TaskGroup):
+            for t in group.tasks:
+                yield (t.suite or group.suite), t
+        else:
+            for g in group.task_groups:
+                for t in g.tasks:
+                    yield (t.suite or g.suite), t
+
+
+def _normalise_language_codes(languages: Iterable[str]) -> list[str]:
+    """Validate requested language codes and fold them onto canonical codes.
+
+    Accepts any spelling the normaliser understands (``de``, ``german``,
+    ``deu_Latn``). Raises ``ValueError`` listing the valid codes if any
+    requested code is unknown.
+    """
+    valid = set(get_all_language_codes())
+    requested: list[str] = []
+    unknown: list[str] = []
+    for code in languages:
+        raw = str(code).strip()
+        if not raw:
+            continue
+        canon = _canonical_language(raw)
+        if canon and canon in valid:
+            if canon not in requested:
+                requested.append(canon)
+        else:
+            unknown.append(raw)
+    if unknown:
+        raise ValueError(
+            f"Unknown language code(s): {', '.join(unknown)}. "
+            f"Valid codes: {', '.join(sorted(valid))}"
+        )
+    return requested
+
+
+def _check_language_match(
+    requested: list[str],
+    matched: set[str],
+    group_names: list[str],
+    has_results: bool,
+) -> None:
+    """Enforce the empty-intersection policy after language filtering.
+
+    Hard-errors when *no* requested language matched any selected task (a
+    well-formed but empty pairing); warns when only *some* languages matched.
+    """
+    scope = (
+        f"task group(s) {{{', '.join(group_names)}}}"
+        if group_names
+        else "any task group"
+    )
+    if not has_results:
+        raise ValueError(
+            f"No tasks in {scope} match language(s) "
+            f"{{{', '.join(requested)}}}."
+        )
+    unmatched = [lang for lang in requested if lang not in matched]
+    if unmatched:
+        logging.warning(
+            "No tasks matched language(s) %s in the selected groups; "
+            "kept language(s) %s.",
+            ", ".join(unmatched),
+            ", ".join(lang for lang in requested if lang in matched),
+        )
+
+
+def _resolve_group_names(
+    group_names: Iterable[str], lang_filter: list[str] | None
+) -> list[str]:
+    """Normalise requested group names; default to all groups when only
+    languages are requested (the ``--languages`` without ``--task_groups`` case)."""
+    names = [str(n).strip() for n in group_names if str(n).strip()]
+    if not names and lang_filter:
+        return get_all_task_group_names()
+    return names
+
+
+def _expand_task_groups(
+    group_names: Iterable[str], languages: Iterable[str] | None = None
+) -> list[TaskGroupResult]:
+    lang_filter = _normalise_language_codes(languages) if languages else None
+    names = _resolve_group_names(group_names, lang_filter)
+
+    parsed = _parse_task_groups(names)
+    missing = set(names) - set(parsed.keys())
     if missing:
         raise ValueError(f"Unknown task group(s): {', '.join(sorted(missing))}")
 
     results: list[TaskGroupResult] = []
+    matched_langs: set[str] = set()
 
-    for _, group in parsed.items():
-        if isinstance(group, TaskGroup):
-            suite = group.suite
-            for t in group.tasks:
-                shots = [int(s) for s in (t.n_shots or [])]
-                task_suite = t.suite or suite
-                for shot in shots:
-                    results.append(
-                        TaskGroupResult(task=t.name, n_shot=shot, suite=task_suite)
-                    )
-        else:
-            for g in group.task_groups:
-                suite = g.suite
-                for t in g.tasks:
-                    shots = [int(s) for s in (t.n_shots or [])]
-                    task_suite = t.suite or suite
-                    for shot in shots:
-                        results.append(
-                            TaskGroupResult(task=t.name, n_shot=shot, suite=task_suite)
-                        )
+    for suite, t in _iter_group_tasks(parsed):
+        if lang_filter is not None:
+            hits = set(t.languages) & set(lang_filter)
+            if not hits:
+                continue
+            matched_langs |= hits
+        for shot in (int(s) for s in (t.n_shots or [])):
+            results.append(TaskGroupResult(task=t.name, n_shot=shot, suite=suite))
+
+    if lang_filter is not None:
+        _check_language_match(lang_filter, matched_langs, names, bool(results))
 
     return results
 
@@ -377,8 +436,12 @@ def _extract_flores_subsets(task_name: str) -> list[str]:
     return []
 
 
-def _collect_dataset_specs(group_names: Iterable[str]) -> list[DatasetSpec]:
-    parsed = _parse_task_groups([str(n).strip() for n in group_names if str(n).strip()])
+def _collect_dataset_specs(
+    group_names: Iterable[str], languages: Iterable[str] | None = None
+) -> list[DatasetSpec]:
+    lang_filter = _normalise_language_codes(languages) if languages else None
+    names = _resolve_group_names(group_names, lang_filter)
+    parsed = _parse_task_groups(names)
 
     specs: list[DatasetSpec] = []
     seen: set[tuple[str, str | None]] = set()
@@ -391,22 +454,14 @@ def _collect_dataset_specs(group_names: Iterable[str]) -> list[DatasetSpec]:
             seen.add(key)
             specs.append(DatasetSpec(repo_id=dataset, subset=subset))
 
-    for _, group in parsed.items():
-        if isinstance(group, TaskGroup):
-            for t in group.tasks:
-                if t.dataset == "facebook/flores" and not t.subset:
-                    for lang in _extract_flores_subsets(t.name):
-                        add_spec(t.dataset, lang)
-                else:
-                    add_spec(t.dataset, t.subset)
+    for _suite, t in _iter_group_tasks(parsed):
+        if lang_filter is not None and not (set(t.languages) & set(lang_filter)):
+            continue
+        if t.dataset == "facebook/flores" and not t.subset:
+            for lang in _extract_flores_subsets(t.name):
+                add_spec(t.dataset, lang)
         else:
-            for g in group.task_groups:
-                for t in g.tasks:
-                    if t.dataset == "facebook/flores" and not t.subset:
-                        for lang in _extract_flores_subsets(t.name):
-                            add_spec(t.dataset, lang)
-                    else:
-                        add_spec(t.dataset, t.subset)
+            add_spec(t.dataset, t.subset)
 
     return specs
 
@@ -481,10 +536,10 @@ def get_all_task_group_names() -> list[str]:
 
 
 def get_all_language_codes() -> list[str]:
-    """Return all language codes requestable as auto-derived task groups."""
+    """Return all language codes accepted by the ``--languages`` filter."""
     data = _load_task_groups_data()
     task_groups = {
         name: TaskGroup.from_dict(name, task_data)
         for name, task_data in data.get("task_groups", {}).items()
     }
-    return sorted(_build_language_groups(task_groups).keys())
+    return sorted(_language_codes_from_groups(task_groups))

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -10,8 +10,10 @@ import yaml
 # --- Language normalisation -------------------------------------------------
 # Tasks encode their language in several incompatible ways across benchmarks
 # (e.g. German is ``deu_Latn``, ``de``, ``German`` and ``deu_latn``). These
-# tables fold every spelling onto a single canonical ``lang_Scri`` code so that
-# a ``group[deu_Latn]`` language bracket can match tasks across benchmarks.
+# tables fold every benchmark spelling onto a single canonical ``lang_Scri``
+# code so that a ``group[deu_Latn]`` bracket can match tasks across benchmarks.
+# Note: this folding applies to the *benchmarks'* internal spellings only — the
+# user-facing bracket accepts the canonical ``lang_Scri`` form exclusively.
 _LANG_ALIAS = {
     # ISO 639-1 two-letter codes (global-mmlu, mgsm, arc-mt)
     "de": "deu_Latn",
@@ -335,11 +337,14 @@ def _iter_group_tasks(
 
 
 def _normalise_language_codes(languages: Iterable[str]) -> list[str]:
-    """Validate requested language codes and fold them onto canonical codes.
+    """Validate requested language codes against the canonical code set.
 
-    Accepts any spelling the normaliser understands (``de``, ``german``,
-    ``deu_Latn``). Raises ``ValueError`` listing the valid codes if any
-    requested code is unknown.
+    Only the precise ``lang_Scri`` form (e.g. ``deu_Latn``) is accepted in a
+    ``group[lang]`` bracket; looser spellings such as ``de`` or ``german`` are
+    rejected so the interface stays unambiguous. When a rejected code is a
+    recognised alias, the error points at the canonical code to use instead.
+    (The alias table is still used internally to *derive* each task's language
+    from the benchmark's own spelling; it just isn't accepted as user input.)
     """
     valid = set(get_all_language_codes())
     requested: list[str] = []
@@ -348,16 +353,19 @@ def _normalise_language_codes(languages: Iterable[str]) -> list[str]:
         raw = str(code).strip()
         if not raw:
             continue
+        if raw in valid:
+            if raw not in requested:
+                requested.append(raw)
+            continue
         canon = _canonical_language(raw)
-        if canon and canon in valid:
-            if canon not in requested:
-                requested.append(canon)
+        if canon and canon in valid and canon != raw:
+            unknown.append(f"{raw} (use {canon})")
         else:
             unknown.append(raw)
     if unknown:
         raise ValueError(
             f"Unknown language code(s): {', '.join(unknown)}. "
-            f"Valid codes: {', '.join(sorted(valid))}"
+            f"Use the precise lang_Scri form. Valid codes: {', '.join(sorted(valid))}"
         )
     return requested
 

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -351,74 +351,153 @@ def _normalise_language_codes(languages: Iterable[str]) -> list[str]:
     return requested
 
 
-def _check_language_match(
-    requested: list[str],
-    matched: set[str],
-    group_names: list[str],
-    has_results: bool,
-) -> None:
-    """Enforce the empty-intersection policy after language filtering.
+_GROUP_SPEC = re.compile(r"^(?P<name>[^\[\]]+?)(?:\[(?P<langs>[^\[\]]*)\])?$")
 
-    Hard-errors when *no* requested language matched any selected task (a
-    well-formed but empty pairing); warns when only *some* languages matched.
+
+def split_group_tokens(raw: str) -> list[str]:
+    """Split a ``--task_groups`` string on top-level commas only.
+
+    Commas inside a per-group ``[...]`` language bracket are preserved so that
+    ``sib200-eu[fra_Latn,deu_Latn],flores200`` splits into two tokens, not
+    three. Blank tokens are dropped.
     """
-    scope = (
-        f"task group(s) {{{', '.join(group_names)}}}"
-        if group_names
-        else "any task group"
-    )
-    if not has_results:
-        raise ValueError(
-            f"No tasks in {scope} match language(s) "
-            f"{{{', '.join(requested)}}}."
-        )
-    unmatched = [lang for lang in requested if lang not in matched]
-    if unmatched:
-        logging.warning(
-            "No tasks matched language(s) %s in the selected groups; "
-            "kept language(s) %s.",
-            ", ".join(unmatched),
-            ", ".join(lang for lang in requested if lang in matched),
-        )
+    tokens: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for ch in raw:
+        if ch == "[":
+            depth += 1
+            current.append(ch)
+        elif ch == "]":
+            depth = max(0, depth - 1)
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            tokens.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    tokens.append("".join(current))
+    return [t.strip() for t in tokens if t.strip()]
 
 
-def _resolve_group_names(
-    group_names: Iterable[str], lang_filter: list[str] | None
-) -> list[str]:
-    """Normalise requested group names; default to all groups when only
-    languages are requested (the ``--languages`` without ``--task_groups`` case)."""
-    names = [str(n).strip() for n in group_names if str(n).strip()]
-    if not names and lang_filter:
-        return get_all_task_group_names()
-    return names
+def _parse_group_spec(token: str) -> tuple[str, list[str] | None]:
+    """Split a group token into ``(name, per_group_languages_or_None)``.
+
+    ``sib200-eu`` -> ``("sib200-eu", None)``; ``sib200-eu[fra_Latn|deu_Latn]``
+    -> ``("sib200-eu", ["fra_Latn", "deu_Latn"])``. Languages inside the
+    bracket may be separated by ``,`` or ``|``. An empty bracket is rejected.
+    """
+    match = _GROUP_SPEC.match(token.strip())
+    if not match:
+        raise ValueError(f"Malformed task group spec: {token!r}")
+    name = match.group("name").strip()
+    langs_raw = match.group("langs")
+    if langs_raw is None:
+        return name, None
+    langs = [part.strip() for part in re.split(r"[,|]", langs_raw) if part.strip()]
+    if not langs:
+        raise ValueError(f"Empty language bracket in task group spec: {token!r}")
+    return name, langs
+
+
+def _resolve_group_specs(
+    group_names: Iterable[str], global_filter: list[str] | None
+) -> list[tuple[str, list[str] | None, bool]]:
+    """Resolve requested group tokens to ``(name, effective_filter, is_explicit)``.
+
+    A per-group ``[...]`` bracket overrides the global ``--languages`` filter for
+    that group (``is_explicit`` True). With no groups but a global filter set,
+    every group is selected with the global filter applied.
+    """
+    specs: list[tuple[str, list[str] | None, bool]] = []
+    for token in (str(n).strip() for n in group_names if str(n).strip()):
+        name, per_langs = _parse_group_spec(token)
+        if per_langs is not None:
+            specs.append((name, _normalise_language_codes(per_langs), True))
+        else:
+            specs.append((name, global_filter, False))
+    if not specs and global_filter:
+        return [(name, global_filter, False) for name in get_all_task_group_names()]
+    return specs
+
+
+def _select_tasks(
+    group_names: Iterable[str], languages: Iterable[str] | None
+) -> list[tuple[str, _Task]]:
+    """Resolve requested groups + language filters to ``(suite, task)`` pairs.
+
+    Applies both the global ``--languages`` filter and any per-group ``[...]``
+    bracket overrides, enforcing the empty-intersection policy: a per-group
+    bracket that matches nothing hard-errors for that group; the global filter
+    hard-errors only if it matches nothing across all the groups it applies to,
+    and warns for languages that matched nothing.
+    """
+    global_filter = _normalise_language_codes(languages) if languages else None
+    specs = _resolve_group_specs(group_names, global_filter)
+
+    parsed = _parse_task_groups([name for name, _, _ in specs])
+    missing = {name for name, _, _ in specs} - set(parsed.keys())
+    if missing:
+        raise ValueError(f"Unknown task group(s): {', '.join(sorted(missing))}")
+
+    selected: list[tuple[str, _Task]] = []
+    global_requested = set(global_filter or [])
+    global_matched: set[str] = set()
+    global_groups = 0
+    global_kept = 0
+
+    for name, filt, is_explicit in specs:
+        group_pairs = list(_iter_group_tasks({name: parsed[name]}))
+        if filt is None:
+            kept = group_pairs
+        else:
+            kept = [(s, t) for s, t in group_pairs if set(t.languages) & set(filt)]
+            matched = {lang for _s, t in kept for lang in t.languages if lang in filt}
+            if is_explicit:
+                if not kept:
+                    raise ValueError(
+                        f"No tasks in task group '{name}' match language(s) "
+                        f"{{{', '.join(filt)}}}."
+                    )
+                unmatched = [lang for lang in filt if lang not in matched]
+                if unmatched:
+                    logging.warning(
+                        "No tasks matched language(s) %s in group '%s'; kept %s.",
+                        ", ".join(unmatched),
+                        name,
+                        ", ".join(lang for lang in filt if lang in matched),
+                    )
+            else:
+                global_groups += 1
+                global_kept += len(kept)
+                global_matched |= matched
+        selected.extend(kept)
+
+    if global_requested and global_groups:
+        if global_kept == 0:
+            raise ValueError(
+                f"No tasks in the selected groups match language(s) "
+                f"{{{', '.join(sorted(global_requested))}}}."
+            )
+        unmatched = sorted(global_requested - global_matched)
+        if unmatched:
+            logging.warning(
+                "No tasks matched language(s) %s in the selected groups; "
+                "kept language(s) %s.",
+                ", ".join(unmatched),
+                ", ".join(sorted(global_matched)),
+            )
+
+    return selected
 
 
 def _expand_task_groups(
     group_names: Iterable[str], languages: Iterable[str] | None = None
 ) -> list[TaskGroupResult]:
-    lang_filter = _normalise_language_codes(languages) if languages else None
-    names = _resolve_group_names(group_names, lang_filter)
-
-    parsed = _parse_task_groups(names)
-    missing = set(names) - set(parsed.keys())
-    if missing:
-        raise ValueError(f"Unknown task group(s): {', '.join(sorted(missing))}")
-
     results: list[TaskGroupResult] = []
-    matched_langs: set[str] = set()
-
-    for suite, t in _iter_group_tasks(parsed):
-        if lang_filter is not None:
-            hits = set(t.languages) & set(lang_filter)
-            if not hits:
-                continue
-            matched_langs |= hits
+    for suite, t in _select_tasks(group_names, languages):
         for shot in (int(s) for s in (t.n_shots or [])):
             results.append(TaskGroupResult(task=t.name, n_shot=shot, suite=suite))
-
-    if lang_filter is not None:
-        _check_language_match(lang_filter, matched_langs, names, bool(results))
-
     return results
 
 
@@ -439,10 +518,6 @@ def _extract_flores_subsets(task_name: str) -> list[str]:
 def _collect_dataset_specs(
     group_names: Iterable[str], languages: Iterable[str] | None = None
 ) -> list[DatasetSpec]:
-    lang_filter = _normalise_language_codes(languages) if languages else None
-    names = _resolve_group_names(group_names, lang_filter)
-    parsed = _parse_task_groups(names)
-
     specs: list[DatasetSpec] = []
     seen: set[tuple[str, str | None]] = set()
 
@@ -454,9 +529,7 @@ def _collect_dataset_specs(
             seen.add(key)
             specs.append(DatasetSpec(repo_id=dataset, subset=subset))
 
-    for _suite, t in _iter_group_tasks(parsed):
-        if lang_filter is not None and not (set(t.languages) & set(lang_filter)):
-            continue
+    for _suite, t in _select_tasks(group_names, languages):
         if t.dataset == "facebook/flores" and not t.subset:
             for lang in _extract_flores_subsets(t.name):
                 add_spec(t.dataset, lang)

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -11,7 +11,7 @@ import yaml
 # Tasks encode their language in several incompatible ways across benchmarks
 # (e.g. German is ``deu_Latn``, ``de``, ``German`` and ``deu_latn``). These
 # tables fold every spelling onto a single canonical ``lang_Scri`` code so that
-# the ``--languages deu_Latn`` filter can match tasks across benchmarks.
+# a ``group[deu_Latn]`` language bracket can match tasks across benchmarks.
 _LANG_ALIAS = {
     # ISO 639-1 two-letter codes (global-mmlu, mgsm, arc-mt)
     "de": "deu_Latn",
@@ -262,7 +262,7 @@ def _load_task_groups_data() -> dict:
 def _language_codes_from_groups(task_groups: dict[str, TaskGroup]) -> set[str]:
     """Collect every canonical language code that at least one task resolves to.
 
-    These are the codes accepted by the ``--languages`` filter; a task resolves
+    These are the codes accepted in a ``group[lang]`` bracket; a task resolves
     to a code via its ``{lang}`` template expansion or its ``subset`` (see
     ``_resolve_task_languages``).
     """
@@ -288,6 +288,17 @@ def _parse_task_groups(
     for super_group_name, super_group_data in data.get("super_groups", {}).items():
         super_groups[super_group_name] = TaskSuperGroup.from_dict(
             super_group_name, super_group_data, task_groups
+        )
+
+    # Reserved super_group spanning every task group, generated from the
+    # registry so it never needs hand-maintaining as groups are added. Pair it
+    # with a [lang] bracket (e.g. ``all[deu_Latn]``) to evaluate a language
+    # across every benchmark. Overlapping tasks are de-duplicated downstream.
+    if "all" not in task_groups and "all" not in super_groups:
+        super_groups["all"] = TaskSuperGroup(
+            name="all",
+            task_groups=list(task_groups.values()),
+            description="Every task group (auto-generated)",
         )
 
     result = {**task_groups, **super_groups}
@@ -401,101 +412,73 @@ def _parse_group_spec(token: str) -> tuple[str, list[str] | None]:
 
 
 def _resolve_group_specs(
-    group_names: Iterable[str], global_filter: list[str] | None
-) -> list[tuple[str, list[str] | None, bool]]:
-    """Resolve requested group tokens to ``(name, effective_filter, is_explicit)``.
+    group_names: Iterable[str],
+) -> list[tuple[str, list[str] | None]]:
+    """Resolve requested group tokens to ``(name, language_filter_or_None)``.
 
-    A per-group ``[...]`` bracket overrides the global ``--languages`` filter for
-    that group (``is_explicit`` True). With no groups but a global filter set,
-    every group is selected with the global filter applied.
+    A per-group ``[...]`` bracket scopes that group (or super_group) to the
+    given language code(s); a bare token applies no language filter.
     """
-    specs: list[tuple[str, list[str] | None, bool]] = []
+    specs: list[tuple[str, list[str] | None]] = []
     for token in (str(n).strip() for n in group_names if str(n).strip()):
         name, per_langs = _parse_group_spec(token)
         if per_langs is not None:
-            specs.append((name, _normalise_language_codes(per_langs), True))
+            specs.append((name, _normalise_language_codes(per_langs)))
         else:
-            specs.append((name, global_filter, False))
-    if not specs and global_filter:
-        return [(name, global_filter, False) for name in get_all_task_group_names()]
+            specs.append((name, None))
     return specs
 
 
-def _select_tasks(
-    group_names: Iterable[str], languages: Iterable[str] | None
-) -> list[tuple[str, _Task]]:
-    """Resolve requested groups + language filters to ``(suite, task)`` pairs.
+def _select_tasks(group_names: Iterable[str]) -> list[tuple[str, _Task]]:
+    """Resolve requested groups to ``(suite, task)`` pairs.
 
-    Applies both the global ``--languages`` filter and any per-group ``[...]``
-    bracket overrides, enforcing the empty-intersection policy: a per-group
-    bracket that matches nothing hard-errors for that group; the global filter
-    hard-errors only if it matches nothing across all the groups it applies to,
-    and warns for languages that matched nothing.
+    A per-group ``[...]`` language bracket keeps only the tasks in that group
+    (or super_group) that resolve to one of the bracketed languages, and
+    hard-errors if it matches nothing in that group.
     """
-    global_filter = _normalise_language_codes(languages) if languages else None
-    specs = _resolve_group_specs(group_names, global_filter)
+    specs = _resolve_group_specs(group_names)
 
-    parsed = _parse_task_groups([name for name, _, _ in specs])
-    missing = {name for name, _, _ in specs} - set(parsed.keys())
+    parsed = _parse_task_groups([name for name, _ in specs])
+    missing = {name for name, _ in specs} - set(parsed.keys())
     if missing:
         raise ValueError(f"Unknown task group(s): {', '.join(sorted(missing))}")
 
     selected: list[tuple[str, _Task]] = []
-    global_requested = set(global_filter or [])
-    global_matched: set[str] = set()
-    global_groups = 0
-    global_kept = 0
-
-    for name, filt, is_explicit in specs:
+    seen: set[tuple[str, str]] = set()
+    for name, filt in specs:
         group_pairs = list(_iter_group_tasks({name: parsed[name]}))
         if filt is None:
             kept = group_pairs
         else:
             kept = [(s, t) for s, t in group_pairs if set(t.languages) & set(filt)]
+            if not kept:
+                raise ValueError(
+                    f"No tasks in task group '{name}' match language(s) "
+                    f"{{{', '.join(filt)}}}."
+                )
             matched = {lang for _s, t in kept for lang in t.languages if lang in filt}
-            if is_explicit:
-                if not kept:
-                    raise ValueError(
-                        f"No tasks in task group '{name}' match language(s) "
-                        f"{{{', '.join(filt)}}}."
-                    )
-                unmatched = [lang for lang in filt if lang not in matched]
-                if unmatched:
-                    logging.warning(
-                        "No tasks matched language(s) %s in group '%s'; kept %s.",
-                        ", ".join(unmatched),
-                        name,
-                        ", ".join(lang for lang in filt if lang in matched),
-                    )
-            else:
-                global_groups += 1
-                global_kept += len(kept)
-                global_matched |= matched
-        selected.extend(kept)
-
-    if global_requested and global_groups:
-        if global_kept == 0:
-            raise ValueError(
-                f"No tasks in the selected groups match language(s) "
-                f"{{{', '.join(sorted(global_requested))}}}."
-            )
-        unmatched = sorted(global_requested - global_matched)
-        if unmatched:
-            logging.warning(
-                "No tasks matched language(s) %s in the selected groups; "
-                "kept language(s) %s.",
-                ", ".join(unmatched),
-                ", ".join(sorted(global_matched)),
-            )
+            unmatched = [lang for lang in filt if lang not in matched]
+            if unmatched:
+                logging.warning(
+                    "No tasks matched language(s) %s in group '%s'; kept %s.",
+                    ", ".join(unmatched),
+                    name,
+                    ", ".join(lang for lang in filt if lang in matched),
+                )
+        # De-duplicate tasks shared by several groups (e.g. the `all` super_group
+        # spans groups whose benchmarks overlap), so they are scheduled once.
+        for suite, t in kept:
+            key = (suite, t.name)
+            if key not in seen:
+                seen.add(key)
+                selected.append((suite, t))
 
     return selected
 
 
-def _expand_task_groups(
-    group_names: Iterable[str], languages: Iterable[str] | None = None
-) -> list[TaskGroupResult]:
+def _expand_task_groups(group_names: Iterable[str]) -> list[TaskGroupResult]:
     results: list[TaskGroupResult] = []
-    for suite, t in _select_tasks(group_names, languages):
+    for suite, t in _select_tasks(group_names):
         for shot in (int(s) for s in (t.n_shots or [])):
             results.append(TaskGroupResult(task=t.name, n_shot=shot, suite=suite))
     return results
@@ -515,9 +498,7 @@ def _extract_flores_subsets(task_name: str) -> list[str]:
     return []
 
 
-def _collect_dataset_specs(
-    group_names: Iterable[str], languages: Iterable[str] | None = None
-) -> list[DatasetSpec]:
+def _collect_dataset_specs(group_names: Iterable[str]) -> list[DatasetSpec]:
     specs: list[DatasetSpec] = []
     seen: set[tuple[str, str | None]] = set()
 
@@ -529,7 +510,7 @@ def _collect_dataset_specs(
             seen.add(key)
             specs.append(DatasetSpec(repo_id=dataset, subset=subset))
 
-    for _suite, t in _select_tasks(group_names, languages):
+    for _suite, t in _select_tasks(group_names):
         if t.dataset == "facebook/flores" and not t.subset:
             for lang in _extract_flores_subsets(t.name):
                 add_spec(t.dataset, lang)
@@ -609,7 +590,7 @@ def get_all_task_group_names() -> list[str]:
 
 
 def get_all_language_codes() -> list[str]:
-    """Return all language codes accepted by the ``--languages`` filter."""
+    """Return all language codes accepted in a ``group[lang]`` bracket."""
     data = _load_task_groups_data()
     task_groups = {
         name: TaskGroup.from_dict(name, task_data)

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -1,9 +1,121 @@
 import copy
+import re
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib.resources import files
 
 import yaml
+
+# --- Language normalisation -------------------------------------------------
+# Tasks encode their language in several incompatible ways across benchmarks
+# (e.g. German is ``deu_Latn``, ``de``, ``German`` and ``deu_latn``). These
+# tables fold every spelling onto a single canonical ``lang_Scri`` code so that
+# per-language task groups (e.g. ``--task_groups deu_Latn``) can be derived.
+_LANG_ALIAS = {
+    # ISO 639-1 two-letter codes (global-mmlu, mgsm, arc-mt)
+    "de": "deu_Latn",
+    "fr": "fra_Latn",
+    "it": "ita_Latn",
+    "es": "spa_Latn",
+    "pt": "por_Latn",
+    "cs": "ces_Latn",
+    "el": "ell_Grek",
+    "lt": "lit_Latn",
+    "nl": "nld_Latn",
+    "pl": "pol_Latn",
+    "ro": "ron_Latn",
+    "ru": "rus_Cyrl",
+    "sr": "srp_Cyrl",
+    "sv": "swe_Latn",
+    "tr": "tur_Latn",
+    "uk": "ukr_Cyrl",
+    "he": "heb_Hebr",
+    "en": "eng_Latn",
+    "bg": "bul_Cyrl",
+    "da": "dan_Latn",
+    "et": "est_Latn",
+    "fi": "fin_Latn",
+    "hu": "hun_Latn",
+    "lv": "lvs_Latn",
+    "sk": "slk_Latn",
+    "sl": "slv_Latn",
+    "is": "isl_Latn",
+    "nb": "nob_Latn",
+    # full English names (include)
+    "albanian": "als_Latn",
+    "armenian": "hye_Armn",
+    "azerbaijani": "aze_Latn",
+    "basque": "eus_Latn",
+    "belarusian": "bel_Cyrl",
+    "bulgarian": "bul_Cyrl",
+    "croatian": "hrv_Latn",
+    "dutch": "nld_Latn",
+    "estonian": "est_Latn",
+    "finnish": "fin_Latn",
+    "french": "fra_Latn",
+    "georgian": "kat_Geor",
+    "german": "deu_Latn",
+    "greek": "ell_Grek",
+    "hungarian": "hun_Latn",
+    "italian": "ita_Latn",
+    "lithuanian": "lit_Latn",
+    "north macedonian": "mkd_Cyrl",
+    "polish": "pol_Latn",
+    "portuguese": "por_Latn",
+    "russian": "rus_Cyrl",
+    "serbian": "srp_Cyrl",
+    "spanish": "spa_Latn",
+    "turkish": "tur_Latn",
+    "ukrainian": "ukr_Cyrl",
+}
+# Distinct individual-language codes folded into a macrolanguage code.
+_LANG_SPECIAL = {"ekk_Latn": "est_Latn"}  # global-piqa uses ekk (Standard Estonian)
+
+
+def _canonical_language(code: str | None) -> str | None:
+    """Normalise any language spelling to a canonical ``lang_Scri`` code."""
+    if code is None:
+        return None
+    code = str(code).strip()
+    low = code.lower()
+    if low in _LANG_ALIAS:
+        return _LANG_ALIAS[low]
+    # lowercase ``lang_scri`` or ``lang_scri_region`` (e.g. ``por_latn_port``)
+    parts = low.split("_")
+    if len(parts) >= 2 and len(parts[0]) == 3 and len(parts[1]) == 4:
+        base = f"{parts[0]}_{parts[1].capitalize()}"
+        return _LANG_SPECIAL.get(base, base)
+    # already canonical ``lang_Scri``
+    if re.match(r"^[a-z]{3}_[A-Z][a-z]{3}$", code):
+        return code
+    return None
+
+
+def _resolve_task_languages(name: str, subset: str | None) -> list[str]:
+    """Return the canonical language code(s) a task belongs to, if any.
+
+    Translation pairs (``flores200:src-tgt``) resolve to their non-English
+    side; every other task resolves via its ``subset``. Tasks with no
+    recognisable language (e.g. English-only standard benchmarks) return [].
+    """
+    if name.startswith("flores200:"):
+        pair = name.split(":", 1)[1]
+        langs = [
+            _canonical_language(part) for part in pair.split("-") if part != "eng_Latn"
+        ]
+        return [lang for lang in langs if lang]
+    lang = _canonical_language(subset)
+    if lang:
+        return [lang]
+    # Some explicitly-listed tasks omit `subset` and encode the language as a
+    # trailing code in the task name (e.g. ``arc_challenge_mt_is``).
+    if subset is None:
+        m = re.search(r"_([a-z]{2})$", name)
+        if m:
+            lang = _canonical_language(m.group(1))
+            if lang:
+                return [lang]
+    return []
 
 
 @dataclass
@@ -19,6 +131,7 @@ class _Task:
     dataset: str | None = None
     subset: str | None = None
     suite: str | None = None
+    languages: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -56,6 +169,7 @@ class TaskGroup:
                     dataset=task_dataset,
                     subset=task_subset,
                     suite=task_data.get("suite"),
+                    languages=_resolve_task_languages(task_name, task_subset),
                 )
             )
 
@@ -144,6 +258,44 @@ def _load_task_groups_data() -> dict:
     return _expand_lang_templates(raw)
 
 
+def _build_language_groups(
+    task_groups: dict[str, TaskGroup],
+) -> dict[str, TaskGroup]:
+    """Derive one virtual TaskGroup per language code.
+
+    Every task that resolves to a language (via its ``{lang}`` template
+    expansion or ``subset``) is collected into a synthetic group named after
+    that canonical code, so ``--task_groups deu_Latn`` yields all German tasks
+    across all benchmarks. Each task's suite is resolved from its origin group
+    and baked on, so a language group can span lm-eval-harness and lighteval.
+    """
+    buckets: dict[str, list[_Task]] = {}
+    for group in task_groups.values():
+        for t in group.tasks:
+            resolved_suite = t.suite or group.suite
+            for lang in t.languages:
+                buckets.setdefault(lang, []).append(
+                    _Task(
+                        name=t.name,
+                        n_shots=t.n_shots,
+                        dataset=t.dataset,
+                        subset=t.subset,
+                        suite=resolved_suite,
+                        languages=t.languages,
+                    )
+                )
+
+    return {
+        lang: TaskGroup(
+            name=lang,
+            tasks=tasks,
+            suite="lm-eval-harness",  # fallback; each task carries its own suite
+            description=f"All evaluation tasks for language '{lang}' (auto-derived)",
+        )
+        for lang, tasks in buckets.items()
+    }
+
+
 def _parse_task_groups(
     requested_groups: list[str],
 ) -> dict[str, TaskSuperGroup | TaskGroup]:
@@ -160,7 +312,11 @@ def _parse_task_groups(
             super_group_name, super_group_data, task_groups
         )
 
-    result = {**task_groups, **super_groups}
+    language_groups = _build_language_groups(task_groups)
+
+    # Explicit task groups / super groups take precedence over derived language
+    # groups on any name collision.
+    result = {**language_groups, **task_groups, **super_groups}
     return {
         group_name: group
         for group_name, group in result.items()
@@ -322,3 +478,13 @@ def get_all_task_group_names() -> list[str]:
     """Return all available task group names (excluding super_groups)."""
     data = _load_task_groups_data()
     return list(data.get("task_groups", {}).keys())
+
+
+def get_all_language_codes() -> list[str]:
+    """Return all language codes requestable as auto-derived task groups."""
+    data = _load_task_groups_data()
+    task_groups = {
+        name: TaskGroup.from_dict(name, task_data)
+        for name, task_data in data.get("task_groups", {}).items()
+    }
+    return sorted(_build_language_groups(task_groups).keys())

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -1,10 +1,10 @@
-"""Tests for the ``--languages`` filter (e.g. --languages deu_Latn).
+"""Tests for per-group language brackets (e.g. ``sib200-eu[deu_Latn]``).
 
 Languages are derived in code from each task's ``{lang}`` template expansion or
-``subset`` (see oellm/task_groups.py), so they require no YAML tagging. They are
-exposed as a filter on ``--task_groups`` rather than as task groups themselves:
-``--languages X`` alone selects all X tasks across every benchmark, while
-``--task_groups G --languages X`` intersects.
+``subset`` (see oellm/task_groups.py), so they require no YAML tagging. A
+``group[lang]`` (or ``super_group[lang]``) bracket keeps only the tasks in that
+group that resolve to one of the bracketed languages; codes inside the bracket
+may be separated by ``,`` or ``|``.
 """
 
 from importlib.resources import files
@@ -39,70 +39,6 @@ def test_language_codes_available():
         assert expected in codes
 
 
-def test_language_filter_alone_expands_and_mixes_suites():
-    # No task groups: select all German tasks across every benchmark.
-    jobs = _expand_task_groups([], languages=["deu_Latn"])
-    assert len(jobs) >= 10
-    # German spans both evaluation suites (belebele-cf + flores are lighteval).
-    suites = {j.suite for j in jobs}
-    assert "lm-eval-harness" in suites
-    assert "lighteval" in suites
-    assert all(isinstance(j.n_shot, int) for j in jobs)
-
-
-def test_language_filter_intersects_with_task_group():
-    # Within sib200-eu only, German narrows to a single sib200 task.
-    jobs = _expand_task_groups(["sib200-eu"], languages=["deu_Latn"])
-    tasks = {j.task for j in jobs}
-    assert tasks == {"sib200_deu_Latn"}
-
-
-def test_language_codes_are_no_longer_task_groups():
-    """A bare language code must not resolve as a task group (the old union
-    footgun); it has to come in via the languages filter instead."""
-    import pytest
-
-    with pytest.raises(ValueError, match="Unknown task group"):
-        _expand_task_groups(["deu_Latn"])
-
-
-def test_empty_intersection_hard_errors():
-    """flores-eu has no Ukrainian side -> a fully empty intersection must raise."""
-    import pytest
-
-    with pytest.raises(ValueError, match="match language"):
-        _expand_task_groups(["flores-200-eu-to-eng"], languages=["ukr_Cyrl"])
-
-
-def test_mgsm_gap_is_handled():
-    """Italian/Portuguese lack mgsm; their filter should still resolve (no crash)
-    and simply omit the mgsm task rather than fail."""
-    for lang in ["ita_Latn", "por_Latn"]:
-        tasks = {j.task for j in _expand_task_groups([], languages=[lang])}
-        assert tasks
-        assert not any(t.startswith("mgsm") for t in tasks)
-
-
-def test_language_filter_collects_dataset_specs():
-    specs = _collect_dataset_specs([], languages=["deu_Latn"])
-    assert specs
-    assert "facebook/belebele" in {s.repo_id for s in specs}
-
-
-def test_unknown_language_code_rejected():
-    with pytest.raises(ValueError, match="Unknown language code"):
-        _expand_task_groups([], languages=["zzz_Fake"])
-
-
-# --- per-group bracket syntax ------------------------------------------------
-
-
-def test_split_group_tokens_is_bracket_aware():
-    assert split_group_tokens("a[x,y],b") == ["a[x,y]", "b"]
-    assert split_group_tokens("sib200-eu , flores200") == ["sib200-eu", "flores200"]
-    assert split_group_tokens("g[x|y]") == ["g[x|y]"]
-
-
 def test_bracket_scopes_language_to_one_group():
     jobs = _expand_task_groups(["sib200-eu[fra_Latn]"])
     assert {j.task for j in jobs} == {"sib200_fra_Latn"}
@@ -122,12 +58,21 @@ def test_bracket_accepts_comma_or_pipe_separator():
     assert comma == pipe == {"sib200_fra_Latn", "sib200_deu_Latn"}
 
 
-def test_bracket_overrides_global_languages_filter():
-    jobs = _expand_task_groups(["sib200-eu[fra_Latn]"], languages=["deu_Latn"])
-    assert {j.task for j in jobs} == {"sib200_fra_Latn"}
+def test_split_group_tokens_is_bracket_aware():
+    assert split_group_tokens("a[x,y],b") == ["a[x,y]", "b"]
+    assert split_group_tokens("sib200-eu , flores200") == ["sib200-eu", "flores200"]
+    assert split_group_tokens("g[x|y]") == ["g[x|y]"]
+
+
+def test_language_codes_are_not_task_groups():
+    """A bare language code must not resolve as a task group (the old union
+    footgun); it only has meaning inside a ``group[lang]`` bracket."""
+    with pytest.raises(ValueError, match="Unknown task group"):
+        _expand_task_groups(["deu_Latn"])
 
 
 def test_bracket_empty_intersection_hard_errors():
+    """flores-eu has no Ukrainian side -> an empty bracket match must raise."""
     with pytest.raises(ValueError, match="No tasks in task group 'flores"):
         _expand_task_groups(["flores-200-eu-to-eng[ukr_Cyrl]"])
 
@@ -135,6 +80,93 @@ def test_bracket_empty_intersection_hard_errors():
 def test_empty_bracket_rejected():
     with pytest.raises(ValueError, match="Empty language bracket"):
         _expand_task_groups(["sib200-eu[]"])
+
+
+def test_unknown_language_code_rejected():
+    with pytest.raises(ValueError, match="Unknown language code"):
+        _expand_task_groups(["sib200-eu[zzz_Fake]"])
+
+
+# --- super_group support -----------------------------------------------------
+
+
+def test_super_group_bracket_resolves_language_subset():
+    """Sampo's request: scoping the oellm-multilingual super_group to a language
+    selects the applicable subset across its member benchmarks, and spans both
+    evaluation suites."""
+    jobs = _expand_task_groups(["oellm-multilingual[deu_Latn]"])
+    tasks = {j.task for j in jobs}
+    assert tasks == {
+        "belebele_deu_Latn",
+        "flores200:deu_Latn-eng_Latn",
+        "flores200:eng_Latn-deu_Latn",
+        "global_mmlu_full_de",
+        "include_base_44_german",
+        "mgsm_native_cot_de",
+    }
+    suites = {j.suite for j in jobs}
+    assert "lm-eval-harness" in suites
+    assert "lighteval" in suites
+
+
+def test_super_group_bracket_collects_dataset_specs():
+    specs = _collect_dataset_specs(["oellm-multilingual[deu_Latn]"])
+    assert specs
+    repos = {s.repo_id for s in specs}
+    assert "facebook/belebele" in repos
+    assert "facebook/flores" in repos
+
+
+def test_all_super_group_is_auto_generated():
+    """The `all` super_group is synthesised from the registry (no YAML entry),
+    so it spans every task group without hand-maintenance, and it is not itself
+    listed as a plain task group."""
+    from oellm.task_groups import get_all_task_group_names
+
+    assert "all" not in get_all_task_group_names()
+    # Reaching it at all proves the synthetic group exists.
+    assert _expand_task_groups(["all"])
+
+
+def test_all_super_group_deduplicates_overlapping_tasks():
+    """Groups inside `all` share some benchmarks (e.g. copa, hellaswag); each
+    (suite, task, n_shot) must be scheduled exactly once."""
+    jobs = _expand_task_groups(["all"])
+    keys = [(j.suite, j.task, j.n_shot) for j in jobs]
+    assert len(keys) == len(set(keys))
+
+
+def test_all_super_group_bracket_spans_whole_registry():
+    """The `all` super_group + [lang] reaches every benchmark's tasks for that
+    language (e.g. German tasks that live outside oellm-multilingual)."""
+    tasks = {j.task for j in _expand_task_groups(["all[deu_Latn]"])}
+    # tasks unique to groups not in oellm-multilingual
+    for extra in [
+        "sib200_deu_Latn",
+        "arc_challenge_mt_de",
+        "belebele_deu_Latn_cf",
+        "global_piqa_completions_deu_latn",
+        "global_piqa_prompted_deu_latn",
+    ]:
+        assert extra in tasks
+    # and still a superset of the curated multilingual subset
+    multiling = {j.task for j in _expand_task_groups(["oellm-multilingual[deu_Latn]"])}
+    assert multiling <= tasks
+
+
+def test_super_group_without_bracket_keeps_all_languages():
+    scoped = _expand_task_groups(["oellm-multilingual[deu_Latn]"])
+    full = _expand_task_groups(["oellm-multilingual"])
+    assert len(full) > len(scoped)
+
+
+def test_mgsm_gap_is_handled():
+    """Italian/Portuguese lack mgsm; scoping the super_group to them should still
+    resolve (no crash) and simply omit the mgsm task rather than fail."""
+    for lang in ["ita_Latn", "por_Latn"]:
+        tasks = {j.task for j in _expand_task_groups([f"oellm-multilingual[{lang}]"])}
+        assert tasks
+        assert not any(t.startswith("mgsm") for t in tasks)
 
 
 def test_templated_tasks_all_resolve_to_a_language():

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -87,6 +87,20 @@ def test_unknown_language_code_rejected():
         _expand_task_groups(["sib200-eu[zzz_Fake]"])
 
 
+@pytest.mark.parametrize("loose", ["de", "german", "German", "deu_latn"])
+def test_loose_spellings_rejected_with_canonical_hint(loose):
+    """Only the precise lang_Scri code is accepted; aliases like `de`/`german`
+    are rejected, and the error points at the canonical code to use instead."""
+    with pytest.raises(ValueError) as excinfo:
+        _expand_task_groups([f"sib200-eu[{loose}]"])
+    assert "use deu_Latn" in str(excinfo.value)
+
+
+def test_canonical_code_still_accepted():
+    jobs = _expand_task_groups(["sib200-eu[deu_Latn]"])
+    assert {j.task for j in jobs} == {"sib200_deu_Latn"}
+
+
 # --- super_group support -----------------------------------------------------
 
 

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -11,12 +11,15 @@ from importlib.resources import files
 
 import yaml
 
+import pytest
+
 from oellm.task_groups import (
     _collect_dataset_specs,
     _expand_task_groups,
     _load_task_groups_data,
     _resolve_task_languages,
     get_all_language_codes,
+    split_group_tokens,
 )
 
 # Multilingual groups still defined with explicit per-language task lists
@@ -88,10 +91,53 @@ def test_language_filter_collects_dataset_specs():
 
 
 def test_unknown_language_code_rejected():
-    import pytest
-
     with pytest.raises(ValueError, match="Unknown language code"):
         _expand_task_groups([], languages=["zzz_Fake"])
+
+
+# --- per-group bracket syntax ------------------------------------------------
+
+
+def test_split_group_tokens_is_bracket_aware():
+    assert split_group_tokens("a[x,y],b") == ["a[x,y]", "b"]
+    assert split_group_tokens("sib200-eu , flores200") == ["sib200-eu", "flores200"]
+    assert split_group_tokens("g[x|y]") == ["g[x|y]"]
+
+
+def test_bracket_scopes_language_to_one_group():
+    jobs = _expand_task_groups(["sib200-eu[fra_Latn]"])
+    assert {j.task for j in jobs} == {"sib200_fra_Latn"}
+
+
+def test_bracket_allows_per_group_languages():
+    jobs = _expand_task_groups(
+        ["sib200-eu[fra_Latn]", "flores-200-eu-to-eng[deu_Latn]"]
+    )
+    assert {j.task for j in jobs} == {
+        "sib200_fra_Latn",
+        "flores200:deu_Latn-eng_Latn",
+    }
+
+
+def test_bracket_accepts_comma_or_pipe_separator():
+    comma = {j.task for j in _expand_task_groups(["sib200-eu[fra_Latn,deu_Latn]"])}
+    pipe = {j.task for j in _expand_task_groups(["sib200-eu[fra_Latn|deu_Latn]"])}
+    assert comma == pipe == {"sib200_fra_Latn", "sib200_deu_Latn"}
+
+
+def test_bracket_overrides_global_languages_filter():
+    jobs = _expand_task_groups(["sib200-eu[fra_Latn]"], languages=["deu_Latn"])
+    assert {j.task for j in jobs} == {"sib200_fra_Latn"}
+
+
+def test_bracket_empty_intersection_hard_errors():
+    with pytest.raises(ValueError, match="No tasks in task group 'flores"):
+        _expand_task_groups(["flores-200-eu-to-eng[ukr_Cyrl]"])
+
+
+def test_empty_bracket_rejected():
+    with pytest.raises(ValueError, match="Empty language bracket"):
+        _expand_task_groups(["sib200-eu[]"])
 
 
 def test_templated_tasks_all_resolve_to_a_language():

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -9,9 +9,8 @@ exposed as a filter on ``--task_groups`` rather than as task groups themselves:
 
 from importlib.resources import files
 
-import yaml
-
 import pytest
+import yaml
 
 from oellm.task_groups import (
     _collect_dataset_specs,
@@ -110,9 +109,7 @@ def test_bracket_scopes_language_to_one_group():
 
 
 def test_bracket_allows_per_group_languages():
-    jobs = _expand_task_groups(
-        ["sib200-eu[fra_Latn]", "flores-200-eu-to-eng[deu_Latn]"]
-    )
+    jobs = _expand_task_groups(["sib200-eu[fra_Latn]", "flores-200-eu-to-eng[deu_Latn]"])
     assert {j.task for j in jobs} == {
         "sib200_fra_Latn",
         "flores200:deu_Latn-eng_Latn",

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -1,7 +1,10 @@
-"""Tests for auto-derived per-language task groups (e.g. --task_groups deu_Latn).
+"""Tests for the ``--languages`` filter (e.g. --languages deu_Latn).
 
 Languages are derived in code from each task's ``{lang}`` template expansion or
-``subset`` (see oellm/task_groups.py), so these groups require no YAML tagging.
+``subset`` (see oellm/task_groups.py), so they require no YAML tagging. They are
+exposed as a filter on ``--task_groups`` rather than as task groups themselves:
+``--languages X`` alone selects all X tasks across every benchmark, while
+``--task_groups G --languages X`` intersects.
 """
 
 from importlib.resources import files
@@ -34,8 +37,9 @@ def test_language_codes_available():
         assert expected in codes
 
 
-def test_language_group_expands_and_mixes_suites():
-    jobs = _expand_task_groups(["deu_Latn"])
+def test_language_filter_alone_expands_and_mixes_suites():
+    # No task groups: select all German tasks across every benchmark.
+    jobs = _expand_task_groups([], languages=["deu_Latn"])
     assert len(jobs) >= 10
     # German spans both evaluation suites (belebele-cf + flores are lighteval).
     suites = {j.suite for j in jobs}
@@ -44,17 +48,41 @@ def test_language_group_expands_and_mixes_suites():
     assert all(isinstance(j.n_shot, int) for j in jobs)
 
 
+def test_language_filter_intersects_with_task_group():
+    # Within sib200-eu only, German narrows to a single sib200 task.
+    jobs = _expand_task_groups(["sib200-eu"], languages=["deu_Latn"])
+    tasks = {j.task for j in jobs}
+    assert tasks == {"sib200_deu_Latn"}
+
+
+def test_language_codes_are_no_longer_task_groups():
+    """A bare language code must not resolve as a task group (the old union
+    footgun); it has to come in via the languages filter instead."""
+    import pytest
+
+    with pytest.raises(ValueError, match="Unknown task group"):
+        _expand_task_groups(["deu_Latn"])
+
+
+def test_empty_intersection_hard_errors():
+    """flores-eu has no Ukrainian side -> a fully empty intersection must raise."""
+    import pytest
+
+    with pytest.raises(ValueError, match="match language"):
+        _expand_task_groups(["flores-200-eu-to-eng"], languages=["ukr_Cyrl"])
+
+
 def test_mgsm_gap_is_handled():
-    """Italian/Portuguese lack mgsm; their groups should still resolve (no crash)
+    """Italian/Portuguese lack mgsm; their filter should still resolve (no crash)
     and simply omit the mgsm task rather than fail."""
     for lang in ["ita_Latn", "por_Latn"]:
-        tasks = {j.task for j in _expand_task_groups([lang])}
+        tasks = {j.task for j in _expand_task_groups([], languages=[lang])}
         assert tasks
         assert not any(t.startswith("mgsm") for t in tasks)
 
 
-def test_language_group_collects_dataset_specs():
-    specs = _collect_dataset_specs(["deu_Latn"])
+def test_language_filter_collects_dataset_specs():
+    specs = _collect_dataset_specs([], languages=["deu_Latn"])
     assert specs
     assert "facebook/belebele" in {s.repo_id for s in specs}
 
@@ -62,8 +90,8 @@ def test_language_group_collects_dataset_specs():
 def test_unknown_language_code_rejected():
     import pytest
 
-    with pytest.raises(ValueError):
-        _expand_task_groups(["zzz_Fake"])
+    with pytest.raises(ValueError, match="Unknown language code"):
+        _expand_task_groups([], languages=["zzz_Fake"])
 
 
 def test_templated_tasks_all_resolve_to_a_language():

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -1,0 +1,84 @@
+"""Tests for auto-derived per-language task groups (e.g. --task_groups deu_Latn).
+
+Languages are derived in code from each task's ``{lang}`` template expansion or
+``subset`` (see oellm/task_groups.py), so these groups require no YAML tagging.
+"""
+
+from importlib.resources import files
+
+import yaml
+
+from oellm.task_groups import (
+    _collect_dataset_specs,
+    _expand_task_groups,
+    _load_task_groups_data,
+    _resolve_task_languages,
+    get_all_language_codes,
+)
+
+# Multilingual groups still defined with explicit per-language task lists
+# (not {lang} templates) whose tasks must also resolve to a language.
+EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include"]
+
+
+def _raw_yaml() -> dict:
+    return (
+        yaml.safe_load((files("oellm.resources") / "task-groups.yaml").read_text()) or {}
+    )
+
+
+def test_language_codes_available():
+    codes = get_all_language_codes()
+    assert len(codes) >= 30
+    for expected in ["deu_Latn", "fra_Latn", "ita_Latn", "spa_Latn", "por_Latn"]:
+        assert expected in codes
+
+
+def test_language_group_expands_and_mixes_suites():
+    jobs = _expand_task_groups(["deu_Latn"])
+    assert len(jobs) >= 10
+    # German spans both evaluation suites (belebele-cf + flores are lighteval).
+    suites = {j.suite for j in jobs}
+    assert "lm-eval-harness" in suites
+    assert "lighteval" in suites
+    assert all(isinstance(j.n_shot, int) for j in jobs)
+
+
+def test_mgsm_gap_is_handled():
+    """Italian/Portuguese lack mgsm; their groups should still resolve (no crash)
+    and simply omit the mgsm task rather than fail."""
+    for lang in ["ita_Latn", "por_Latn"]:
+        tasks = {j.task for j in _expand_task_groups([lang])}
+        assert tasks
+        assert not any(t.startswith("mgsm") for t in tasks)
+
+
+def test_language_group_collects_dataset_specs():
+    specs = _collect_dataset_specs(["deu_Latn"])
+    assert specs
+    assert "facebook/belebele" in {s.repo_id for s in specs}
+
+
+def test_unknown_language_code_rejected():
+    import pytest
+
+    with pytest.raises(ValueError):
+        _expand_task_groups(["zzz_Fake"])
+
+
+def test_templated_tasks_all_resolve_to_a_language():
+    """Every task in a group that uses `valid_langs` templating, plus the
+    explicit multilingual groups, must resolve to a language code. Guards
+    against a new language spelling that the normaliser doesn't recognise."""
+    raw = _raw_yaml()["task_groups"]
+    templated = [name for name, g in raw.items() if g.get("valid_langs")]
+    assert templated, "expected at least one {lang}-templated group"
+
+    expanded = _load_task_groups_data()["task_groups"]
+    for name in templated + EXPLICIT_MULTILINGUAL_GROUPS:
+        for task in expanded[name]["tasks"]:
+            langs = _resolve_task_languages(task["task"], task.get("subset"))
+            assert langs, (
+                f"{name}: task {task['task']} (subset={task.get('subset')}) "
+                "did not resolve to a language"
+            )


### PR DESCRIPTION
Adds an auto-derived task group for every language, so a monolingual model can be evaluated against all available benchmarks for its language with one canonical `lang_Script` code:
  
  ```bash
  oellm-eval schedule --models my-model --task_groups deu_Latn
  oellm-eval schedule --models my-model --task_groups "fra_Latn,ita_Latn,por_Latn"
  ```


**Changes:**
 - oellm/task_groups.py: Building on the {lang} template work in #76, each task's language is derived in code from its {lang}/subset value (or the non-English side of a flores200: pair), normalised to a canonical lang_Script code. Tasks sharing a language are collected into a synthetic TaskGroup named after that code.

  - _canonical_language / _resolve_task_languages: fold the four spellings used across benchmarks (deu_Latn / de / German / deu_latn) onto one code.
  - _build_language_groups: derive one group per language, baking each task's resolved suite so a group can span lm-eval-harness and lighteval.
  - get_all_language_codes(): list the derived codes.
 
**Testing:**

  - tests/test_language_groups.py: derivation, mixed-suite routing, dataset-spec collection, unknown-code rejection, and a coverage guard asserting every task in a valid_langs-templated group (plus the explicit mgsm-eu/include groups) resolves to a language, so a new language spelling can't silently drop out.

**_Notes_**:
  - **MGSM gap**: ita_Latn/por_Latn have no GSM math eval because jbross-ibm-research/mgsm ships no it/pt configs  (not a missing tag).
  - **Untagged groups** (generic-multilingual, English-only standard suites) are left out of language groups by design.
