### PR TITLE
add jeopardy via custom lm-eval task

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/jeopardy.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/jeopardy.yaml
@@ -1,0 +1,28 @@
+task: jeopardy
+dataset_path: openeurollm/jeopardy
+test_split: test
+fewshot_split: test
+output_type: generate_until
+doc_to_text: "{{context}}\nAnswer:"
+doc_to_target: "{{continuation}}"
+target_delimiter: " "
+fewshot_delimiter: "\n"
+should_decontaminate: true
+doc_to_decontamination_query: context
+generation_kwargs:
+  until:
+    - "\n"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 48
+filter_list:
+  - name: strict-match
+    filter:
+      - function: remove_whitespace
+      - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -442,10 +442,9 @@ task_groups:
       - task: squadv2
         n_shots: [10]
         dataset: rajpurkar/squad_v2
-      # TODO: jeopardy is not available in lm-eval-harness.
-      # - task: jeopardy
-      #   n_shots: [10]
-      #   dataset: openaccess-ai-collective/jeopardy
+      - task: jeopardy
+        n_shots: [10]
+        dataset: openeurollm/jeopardy
 
   arc-challenge-mt-eu:
     description: "ARC Challenge multilingual (22 European languages)"


### PR DESCRIPTION
(1) **Parity**: validated against DCLM's published score (Qwen2-7B, 10-shot) = 0.481 here vs 0.489 [published](https://github.com/mlfoundations/dclm/blob/361714bdd60bb9b7f4b2d8354cebbf0dec0c329e/exp_data/evals/evaluation_Qwen_Qwen2-7B.json#L10)

(2) **Data**: `openeurollm/jeopardy` - DCLM subset (2117 Qs), sourced from [mosaicml/llm-foundry](https://github.com/mosaicml/llm-foundry/blob/main/scripts/eval/local_data/world_knowledge/jeopardy_all.jsonl)
