### PR TITLE
Add MMLU-ProX

### DIFF
--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -1,5 +1,15 @@
 task_metrics:
   mmlu: acc
+  mmlu_prox_cs: exact_match
+  mmlu_prox_de: exact_match
+  mmlu_prox_en: exact_match
+  mmlu_prox_es: exact_match
+  mmlu_prox_fr: exact_match
+  mmlu_prox_hu: exact_match
+  mmlu_prox_it: exact_match
+  mmlu_prox_pt: exact_match
+  mmlu_prox_sr: exact_match
+  mmlu_prox_uk: exact_match
   sib200_bul_Cyrl: acc_norm
   sib200_hrv_Latn: acc_norm
   sib200_ces_Latn: acc_norm
@@ -281,6 +291,15 @@ task_groups:
     valid_langs: [cs, de, el, en, es, fr, it, lt, nl, pl, pt, ro, ru, sr, sv, tr, uk, he]
     tasks:
       - task: "global_mmlu_full_{lang}"
+        subset: "{lang}"
+  mmlu-prox-eu:
+    description: "MMLU-ProX EU subset, 5-shot CoT, exact-match."
+    suite: lm-eval-harness
+    n_shots: [5]
+    dataset: li-lab/MMLU-ProX
+    valid_langs: [cs, de, en, es, fr, hu, it, pt, sr, uk]
+    tasks:
+      - task: "mmlu_prox_{lang}"
         subset: "{lang}"
   mgsm-eu:
     description: "EU Language GSM benchmarks in Aya Expanse"


### PR DESCRIPTION
## Summary

Adds the **MMLU-ProX** eval (lm-eval-harness), restricted to the EU-language subset the dataset ships: `cs, de, en, es, fr, hu, it, pt, sr, uk`. One of the Evals from https://github.com/OpenEuroLLM/oellm-eval/issues/89

Relies on lm-eval-harness's built-in `mmlu_prox_<lang>` tasks — the 5-shot CoT prompt, the per-language `custom-extract` answer regex, and the `exact_match` metric all come straight from that implementation.

## Changes

- **`task-groups.yaml`** — new `mmlu-prox-eu` group (5-shot, `dataset: li-lab/MMLU-ProX`) using the `{lang}` template, plus an `exact_match` `task_metrics` line per language. 

## Validation

- Ran `mmlu_prox_de` 5-shot on Qwen3.5-2B-Base (limit 8/subject): exact_match = 0.26 ±0.04, clearly above the ~0.10 ten-option random floor, confirming pipeline.
