### PR TITLE
Add XCSQA

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/_default_template_yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/_default_template_yaml
@@ -1,0 +1,24 @@
+tag:
+  - xcsqa
+dataset_path: INK-USC/xcsr
+output_type: multiple_choice
+test_split: validation
+fewshot_split: validation
+fewshot_config:
+  sampler: first_n
+doc_to_text: "Question: {{question.stem}}\nAnswer:"
+doc_to_target: "{{question.choices.label.index(answerKey)}}"
+doc_to_choice: "{{question.choices.text}}"
+should_decontaminate: true
+doc_to_decontamination_query: "Question: {{question.stem}}\nAnswer:"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_deu_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_deu_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-de
+include: _default_template_yaml
+task: xcsqa_deu_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_eng_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_eng_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-en
+include: _default_template_yaml
+task: xcsqa_eng_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_fra_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_fra_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-fr
+include: _default_template_yaml
+task: xcsqa_fra_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_ita_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_ita_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-it
+include: _default_template_yaml
+task: xcsqa_ita_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_nld_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_nld_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-nl
+include: _default_template_yaml
+task: xcsqa_nld_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_pol_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_pol_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-pl
+include: _default_template_yaml
+task: xcsqa_pol_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_por_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_por_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-pt
+include: _default_template_yaml
+task: xcsqa_por_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_spa_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xcsqa/xcsqa_spa_Latn.yaml
@@ -1,0 +1,3 @@
+dataset_name: X-CSQA-es
+include: _default_template_yaml
+task: xcsqa_spa_Latn

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -62,6 +62,14 @@ task_metrics:
   belebele_nob_Latn_cf: acc_norm
   belebele_eus_Latn_cf: acc_norm
   belebele_cat_Latn_cf: acc_norm
+  xcsqa_deu_Latn: acc_norm
+  xcsqa_eng_Latn: acc_norm
+  xcsqa_spa_Latn: acc_norm
+  xcsqa_fra_Latn: acc_norm
+  xcsqa_ita_Latn: acc_norm
+  xcsqa_nld_Latn: acc_norm
+  xcsqa_pol_Latn: acc_norm
+  xcsqa_por_Latn: acc_norm
   copa: acc
   lambada_openai: acc
   openbookqa: acc_norm
@@ -302,7 +310,30 @@ task_groups:
     tasks:
       - task: "belebele_{lang}_cf"
         subset: "{lang}"
-      
+
+  xcsqa-eu:
+    description: "XCSQA EU commonsense QA (0-shot MCQ, acc_norm)"
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: INK-USC/xcsr
+    tasks:
+      - task: xcsqa_deu_Latn
+        subset: X-CSQA-de
+      - task: xcsqa_eng_Latn
+        subset: X-CSQA-en
+      - task: xcsqa_spa_Latn
+        subset: X-CSQA-es
+      - task: xcsqa_fra_Latn
+        subset: X-CSQA-fr
+      - task: xcsqa_ita_Latn
+        subset: X-CSQA-it
+      - task: xcsqa_nld_Latn
+        subset: X-CSQA-nl
+      - task: xcsqa_pol_Latn
+        subset: X-CSQA-pl
+      - task: xcsqa_por_Latn
+        subset: X-CSQA-pt
+
   flores-200-eu-to-eng:
     description: "Flores 200 EU to English translation"
     suite: lighteval

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -72,6 +72,16 @@ _LANG_ALIAS = {
     "spanish": "spa_Latn",
     "turkish": "tur_Latn",
     "ukrainian": "ukr_Cyrl",
+    # xcsqa: the group's `subset` is the HF config (`X-CSQA-<iso1>`, needed for
+    # pre-download), so the language is derived from that config spelling here.
+    "x-csqa-de": "deu_Latn",
+    "x-csqa-en": "eng_Latn",
+    "x-csqa-es": "spa_Latn",
+    "x-csqa-fr": "fra_Latn",
+    "x-csqa-it": "ita_Latn",
+    "x-csqa-nl": "nld_Latn",
+    "x-csqa-pl": "pol_Latn",
+    "x-csqa-pt": "por_Latn",
 }
 # Distinct individual-language codes folded into a macrolanguage code.
 _LANG_SPECIAL = {"ekk_Latn": "est_Latn"}  # global-piqa uses ekk (Standard Estonian)

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -23,7 +23,7 @@ from oellm.task_groups import (
 
 # Multilingual groups still defined with explicit per-language task lists
 # (not {lang} templates) whose tasks must also resolve to a language.
-EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include"]
+EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include", "xcsqa-eu"]
 
 
 def _raw_yaml() -> dict:


### PR DESCRIPTION
## Summary

One of the Evals from #89. I added XCSQA (X-CSQA, the commonsense QA task of the XCSR benchmark, [INK-USC/xcsr](https://huggingface.co/datasets/INK-USC/xcsr)) as a new `xcsqa-eu` task group, restricted to the EU-language subset the dataset ships: **de, en, es, fr, it, nl, pl, pt**.

## Implementation

- Custom lm-eval-harness multiple-choice task under `oellm/resources/custom_lm_eval_tasks/xcsqa/`, modeled on `arc_mt`: validation split, 0-shot, log-prob choice scoring, `acc`/`acc_norm` (`acc_norm` is the char-length-normalized accuracy that the working lighteval CF groups such as `belebele-eu-cf` report).
- Registered `xcsqa-eu` in `task-groups.yaml` with one `task_metrics: acc_norm` entry per language, added the `X-CSQA-<iso1>` config spellings to `_LANG_ALIAS`, and registered the group in `EXPLICIT_MULTILINGUAL_GROUPS` so `xcsqa-eu[deu_Latn]` bracket scoping resolves (verified).

## Why not lighteval's built-in xcsqa

lighteval ships xcsqa, but its task definitions hardcode a `LogProbPMINorm` metric that lighteval 0.13 cannot compute: the prompt template sets `unconditioned_query`, yet nothing in the package builds the unconditioned requests, so every task aborts with `AssertionError: unconditioned_logprob must be provided for PMI normalization`. I verified this on GPU — both test languages crashed with zero results. The lighteval groups that do work here (`belebele-eu-cf`, flores) omit PMI from their metric lists, and our runner has no `--custom-tasks` path to override the metrics, so I ported the task to lm-eval-harness instead.

## Validation

No upstream implementation is runnable for this setup, so I recorded Qwen/Qwen3.5-0.8B-Base (0-shot, validation split) as the initial baseline:

| lang | acc | acc_norm |
|------|------|----------|
| eng | 0.416 | 0.360 |
| fra | 0.276 | 0.268 |
| por | 0.274 | 0.284 |
| spa | 0.272 | 0.267 |
| deu | 0.269 | 0.270 |
| ita | 0.259 | 0.269 |
| nld | 0.236 | 0.274 |
| pol | 0.224 | 0.255 |

Every language is above the 0.20 five-way chance floor with the expected English lead. Guard tests (`test_language_groups`, `test_task_groups`, `test_datasets`), ruff, and yamllint all pass.