### PR TITLE
Add Global-MGSM

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/_global_mgsm_template_yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/_global_mgsm_template_yaml
@@ -1,0 +1,36 @@
+# Global-MGSM (CohereLabs/global-mgsm) — multilingual grade-school math.
+# The dataset ships a localized `instruction` (asking for chain-of-thought
+# reasoning followed by the final integer on an "Answer:"-style line) and a
+# localized `answer_prefix` per example, so the prompt is uniform across
+# languages. Because the answer prefix is localized, the score uses the
+# language-agnostic flexible-extract filter (last number in the generation),
+# taken verbatim from lm-eval-harness's MGSM task, plus exact_match.
+dataset_path: CohereLabs/global-mgsm
+output_type: generate_until
+test_split: test
+doc_to_text: "{{instruction}}\n\n{{question}}"
+doc_to_target: "{{answer}}"
+generation_kwargs:
+  until:
+    - "\n\n\n"
+    - "\n\nQuestion"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 512
+filter_list:
+  - name: "flexible-extract"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(-?[$0-9.,]{2,})|(-?[0-9]+)"
+      - function: "take_first"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+metadata:
+  version: 0.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_ca.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_ca.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "ca"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_ca"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_cs.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_cs.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "cs"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_cs"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_de.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_de.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "de"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_de"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_el.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_el.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "el"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_el"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_en.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_en.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "en"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_en"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_es.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_es.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "es"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_es"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_eu.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_eu.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "eu"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_eu"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_fr.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_fr.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "fr"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_fr"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_gl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_gl.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "gl"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_gl"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_hu.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_hu.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "hu"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_hu"
+"test_split": "test"

--- a/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_sr.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/global_mgsm/global_mgsm_sr.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "sr"
+"include": "_global_mgsm_template_yaml"
+"task": "global_mgsm_sr"
+"test_split": "test"

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -92,6 +92,18 @@ task_metrics:
   arc_challenge_mt_nb: acc_norm
   boolq: acc
   commonsense_qa: acc
+  # global-mgsm (CohereLabs/global-mgsm): flexible-extract exact_match
+  global_mgsm_ca: exact_match
+  global_mgsm_cs: exact_match
+  global_mgsm_de: exact_match
+  global_mgsm_el: exact_match
+  global_mgsm_en: exact_match
+  global_mgsm_es: exact_match
+  global_mgsm_eu: exact_match
+  global_mgsm_fr: exact_match
+  global_mgsm_gl: exact_match
+  global_mgsm_hu: exact_match
+  global_mgsm_sr: exact_match
   hellaswag: acc_norm
   piqa: acc_norm
   social_iqa: acc
@@ -346,6 +358,16 @@ task_groups:
         subset: es
       - task: mgsm_native_cot_fr
         subset: fr
+
+  global-mgsm-eu:
+    description: "Global-MGSM EU grade-school math (0-shot, exact_match)."
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: CohereLabs/global-mgsm
+    valid_langs: [de, fr, es, el, cs, hu, en, ca, eu, gl, sr]
+    tasks:
+      - task: "global_mgsm_{lang}"
+        subset: "{lang}"
 
   generic-multilingual:
     description: "Generic multilingual benchmarks in Aya Expanse"

--- a/oellm/task_groups.py
+++ b/oellm/task_groups.py
@@ -46,6 +46,9 @@ _LANG_ALIAS = {
     "nb": "nob_Latn",
     "no": "nob_Latn",
     "hr": "hrv_Latn",
+    "ca": "cat_Latn",
+    "eu": "eus_Latn",
+    "gl": "glg_Latn",
     # full English names (include)
     "albanian": "als_Latn",
     "armenian": "hye_Armn",


### PR DESCRIPTION
## What

I added **Global-MGSM** (`CohereLabs/global-mgsm`, multilingual grade-school math) as a new `global-mgsm-eu` group. Neither lm-eval-harness nor lighteval ships it, so this is a custom lm-eval task under `custom_lm_eval_tasks/global_mgsm/` (https://github.com/OpenEuroLLM/oellm-eval/issues/89). It is distinct from the existing `mgsm-eu` (standard MGSM, 4 languages).

## How

- **Prompt** uses the dataset's own localized `instruction` + `question` (the instruction asks for chain-of-thought reasoning then the final integer), so the template is uniform across languages.
- **Metric** is `exact_match` via lm-eval's MGSM **flexible-extract** filter (last number in the generation), taken verbatim from lm-eval. This is language-agnostic, which matters because Global-MGSM's answer prefixes are localized per language.
- **0-shot** — the dataset only has a `test` split and the Aya-style instruction is designed for 0-shot.
- **EU subset only (11 languages):** `ca, cs, de, el, en, es, eu, fr, gl, hu, sr` — the intersection of the EU set with what Global-MGSM ships. I added `ca -> cat_Latn`, `eu -> eus_Latn`, `gl -> glg_Latn` to `_LANG_ALIAS` so every task resolves to canonical `lang_Scri` (bracket scoping like `global-mgsm-eu[deu_Latn]` verified).

## Validation

There is no built-in upstream task and no published base-model number (Cohere reports Global-MGSM only for instruction-tuned models), so I record our measured number as the **initial baseline**. On Qwen3.5-2B-Base, 0-shot, I inspected generations (prompt → CoT → extracted final number → `exact_match`) and confirmed `collect` reports `exact_match,flexible-extract`:

| task | exact_match (Qwen3.5-2B-Base, 0-shot) |
|------|--------------------------------------:|
| `global_mgsm_de` | 0.45 |
| `global_mgsm_en` | 0.40 |