### PR TITLE
Add HumanEval, AIME24, AIME25, AMC23

### DIFF
--- a/docs/VENV.md
+++ b/docs/VENV.md
@@ -76,7 +76,7 @@ oellm-eval schedule \
 
 ## Evalchemy (reasoning)
 
-The `reasoning` task group includes 6 benchmarks: GSM8k, IFEval, and MBPP run via lm-eval-harness, while GPQADiamond, MATH500, and LiveCodeBench run via evalchemy.
+The `reasoning` task group includes 10 benchmarks: GSM8k, IFEval, and MBPP run via lm-eval-harness, while GPQADiamond, MATH500, LiveCodeBench, HumanEval, AIME24, AIME25, and AMC23 run via evalchemy.
 
 > **Note:** The evalchemy versions of GPQA and MATH500 differ from lm-eval-harness. Evalchemy uses free-form generation with CoT reasoning instead of log-likelihood scoring.
 

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -458,7 +458,7 @@ task_groups:
       - task: arc_challenge_mt_is  # no subset in the source dataset
 
   reasoning:
-    description: "Reasoning tasks: GSM8k (4-shot), IFEval (0-shot), MBPP (3-shot), GPQA-Diamond (0-shot), MATH500 (0-shot), LiveCodeBench (0-shot)"
+    description: "Reasoning tasks: GSM8k (4-shot), IFEval (0-shot), MBPP (3-shot), GPQA-Diamond (0-shot), MATH500 (0-shot), LiveCodeBench (0-shot), HumanEval (0-shot), AIME24 (0-shot), AIME25 (0-shot), AMC23 (0-shot)"
     suite: lm-eval-harness
     tasks:
       - task: gsm8k
@@ -481,6 +481,18 @@ task_groups:
         n_shots: [0]
         suite: evalchemy
         dataset: livecodebench/code_generation_lite
+      - task: HumanEval
+        n_shots: [0]
+        suite: evalchemy
+      - task: AIME24
+        n_shots: [0]
+        suite: evalchemy
+      - task: AIME25
+        n_shots: [0]
+        suite: evalchemy
+      - task: AMC23
+        n_shots: [0]
+        suite: evalchemy
 
   global-piqa-eu-completions:
     description: "Global PIQA European languages — multiple-choice completions (0-shot, mrlbenchmarks/global-piqa-nonparallel)"

--- a/requirements-venv-evalchemy.txt
+++ b/requirements-venv-evalchemy.txt
@@ -13,3 +13,4 @@ torch
 
 langdetect
 immutabledict
+fire


### PR DESCRIPTION

Ran the new tasks on `ali-elganzory/Qwen3-1.7B-Base-SFT-Tulu3-decontaminated`:

| Benchmark | Our result | Reference |
|---|---|---|
| HumanEval | 65.2 (python pass@1) | 64.6 |
| AMC23 | 12.5 | 12.5 |
| AIME25 | 0.0 | 0.0 | 
| AIME24 | 0.0| 10.0 |  

Note: trying to debug AIME24