### PR TITLE
Add XNLI EU task group

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/xnli/_default_template_yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xnli/_default_template_yaml
@@ -1,0 +1,22 @@
+tag:
+  - xnli_eu
+# Same prompt format as lm-eval's built-in xnli tasks, but with the canonical
+# `facebook/xnli` dataset id: the built-in tasks still point at the legacy
+# `xnli` id, which recent huggingface_hub versions reject ("Repository id must
+# be 'namespace/name'") and which cannot be resolved from a pre-downloaded
+# cache on offline compute nodes.
+dataset_path: facebook/xnli
+output_type: multiple_choice
+training_split: train
+test_split: validation
+fewshot_split: train
+fewshot_config:
+  sampler: first_n
+doc_to_text: ""
+doc_to_target: label
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/oellm/resources/custom_lm_eval_tasks/xnli/xnli_bul_Cyrl.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xnli/xnli_bul_Cyrl.yaml
@@ -1,0 +1,4 @@
+dataset_name: bg
+doc_to_choice: '{{[premise+", правилно? да, "+hypothesis,premise+", правилно? така, "+hypothesis,premise+", правилно? не, "+hypothesis]}}'
+include: _default_template_yaml
+task: xnli_bul_Cyrl

--- a/oellm/resources/custom_lm_eval_tasks/xnli/xnli_deu_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xnli/xnli_deu_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: de
+doc_to_choice: '{{[premise+", richtig? Ja, "+hypothesis,premise+", richtig? Auch, "+hypothesis,premise+", richtig? Nein, "+hypothesis]}}'
+include: _default_template_yaml
+task: xnli_deu_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xnli/xnli_ell_Grek.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xnli/xnli_ell_Grek.yaml
@@ -1,0 +1,4 @@
+dataset_name: el
+doc_to_choice: '{{[premise+", σωστός? Ναί, "+hypothesis,premise+", σωστός? Έτσι, "+hypothesis,premise+", σωστός? όχι, "+hypothesis]}}'
+include: _default_template_yaml
+task: xnli_ell_Grek

--- a/oellm/resources/custom_lm_eval_tasks/xnli/xnli_eng_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xnli/xnli_eng_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: en
+doc_to_choice: '{{[premise+", right? Yes, "+hypothesis,premise+", right? Also, "+hypothesis,premise+", right? No, "+hypothesis]}}'
+include: _default_template_yaml
+task: xnli_eng_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xnli/xnli_fra_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xnli/xnli_fra_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: fr
+doc_to_choice: '{{[premise+", correct? Oui, "+hypothesis,premise+", correct? Aussi, "+hypothesis,premise+", correct? Non, "+hypothesis]}}'
+include: _default_template_yaml
+task: xnli_fra_Latn

--- a/oellm/resources/custom_lm_eval_tasks/xnli/xnli_spa_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/xnli/xnli_spa_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: es
+doc_to_choice: '{{[premise+", correcto? Sí, "+hypothesis,premise+", correcto? Asi que, "+hypothesis,premise+", correcto? No, "+hypothesis]}}'
+include: _default_template_yaml
+task: xnli_spa_Latn

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -80,6 +80,12 @@ task_metrics:
   xcsqa_nld_Latn: acc_norm
   xcsqa_pol_Latn: acc_norm
   xcsqa_por_Latn: acc_norm
+  xnli_bul_Cyrl: acc
+  xnli_deu_Latn: acc
+  xnli_ell_Grek: acc
+  xnli_eng_Latn: acc
+  xnli_spa_Latn: acc
+  xnli_fra_Latn: acc
   copa: acc
   lambada_openai: acc
   openbookqa: acc_norm
@@ -450,6 +456,25 @@ task_groups:
         subset: X-CSQA-pl
       - task: xcsqa_por_Latn
         subset: X-CSQA-pt
+
+  xnli-eu:
+    description: "XNLI EU natural language inference (0-shot, acc)"
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: facebook/xnli
+    tasks:
+      - task: xnli_bul_Cyrl
+        subset: bg
+      - task: xnli_deu_Latn
+        subset: de
+      - task: xnli_ell_Grek
+        subset: el
+      - task: xnli_eng_Latn
+        subset: en
+      - task: xnli_spa_Latn
+        subset: es
+      - task: xnli_fra_Latn
+        subset: fr
 
   flores-200-eu-to-eng:
     description: "Flores 200 EU->English translation (0-shot, chrf++)."

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -23,7 +23,7 @@ from oellm.task_groups import (
 
 # Multilingual groups still defined with explicit per-language task lists
 # (not {lang} templates) whose tasks must also resolve to a language.
-EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include", "xcsqa-eu"]
+EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include", "xcsqa-eu", "xnli-eu"]
 
 
 def _raw_yaml() -> dict:


### PR DESCRIPTION
## Summary

One of the evals from #89. Adds XNLI ([facebook/xnli](https://huggingface.co/datasets/facebook/xnli)) as a new `xnli-eu` task group, restricted to the EU-language subset the dataset ships: **bg, de, el, en, es, fr**.

## Implementation

Custom lm-eval-harness tasks under `oellm/resources/custom_lm_eval_tasks/xnli/`, modeled on `xcsqa`, with the same cloze prompt format as the harness's built-in xnli tasks. Custom tasks (rather than the built-ins) because the built-ins still point at the legacy bare `xnli` dataset id, which recent huggingface_hub versions reject (`Repository id must be 'namespace/name'`) and which cannot be resolved from a pre-downloaded cache on offline compute nodes. Task names use the `xnli_<lang_Scri>` convention to avoid clashing with the built-in `xnli_<iso1>` names, and the tag is `xnli_eu` so the harness's own `xnli` group is left untouched.

0-shot, `acc` (log-prob choice scoring). Registered in `task-groups.yaml` with per-language `task_metrics` entries and added to the explicit multilingual groups in the tests.

## Testing

- Full unit test suite passes (100 tests), ruff clean.
- Group expansion, `xnli-eu[deu_Latn|ell_Grek]` bracket filtering, and dataset pre-download specs (`facebook/xnli` × 6 configs) verified.
- End-to-end `lm_eval` run of `xnli_deu_Latn` and `xnli_fra_Latn` (pythia-14m, `--limit 8`) completes with chance-level accuracy as expected for a 14M model on 3-way NLI.