### PR TITLE
Add PAWS-X EU task group

### DIFF
--- a/oellm/resources/custom_lm_eval_tasks/pawsx/_default_template_yaml
+++ b/oellm/resources/custom_lm_eval_tasks/pawsx/_default_template_yaml
@@ -1,0 +1,22 @@
+tag:
+  - pawsx_eu
+# Same prompt format as lm-eval's built-in paws-x tasks, but with the canonical
+# `google-research-datasets/paws-x` dataset id: the built-in tasks still point
+# at the legacy `paws-x` id, which recent huggingface_hub versions reject
+# ("Repository id must be 'namespace/name'") and which cannot be resolved from
+# a pre-downloaded cache on offline compute nodes.
+dataset_path: google-research-datasets/paws-x
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+process_docs: !function utils.process_docs_paraphrases
+doc_to_text: ""
+doc_to_target: label
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_deu_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_deu_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: de
+doc_to_choice: '{{[sentence1+", richtig? Nein, "+sentence2, sentence1+", richtig? Ja, "+sentence2]}}'
+include: _default_template_yaml
+task: pawsx_deu_Latn

--- a/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_eng_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_eng_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: en
+doc_to_choice: '{{[sentence1+", right? No, "+sentence2, sentence1+", right? Yes, "+sentence2]}}'
+include: _default_template_yaml
+task: pawsx_eng_Latn

--- a/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_fra_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_fra_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: fr
+doc_to_choice: '{{[sentence1+", n''est-ce pas? Non, "+sentence2, sentence1+", n''est-ce pas? Oui, "+sentence2]}}'
+include: _default_template_yaml
+task: pawsx_fra_Latn

--- a/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_spa_Latn.yaml
+++ b/oellm/resources/custom_lm_eval_tasks/pawsx/pawsx_spa_Latn.yaml
@@ -1,0 +1,4 @@
+dataset_name: es
+doc_to_choice: '{{[sentence1+", verdad? No, "+sentence2, sentence1+", verdad? Sí, "+sentence2]}}'
+include: _default_template_yaml
+task: pawsx_spa_Latn

--- a/oellm/resources/custom_lm_eval_tasks/pawsx/utils.py
+++ b/oellm/resources/custom_lm_eval_tasks/pawsx/utils.py
@@ -1,0 +1,44 @@
+import re
+
+
+def general_detokenize(string):
+    string = string.replace(" n't", "n't")
+    string = string.replace(" )", ")")
+    string = string.replace("( ", "(")
+    string = string.replace('" ', '"')
+    string = string.replace(' "', '"')
+    string = re.sub(r" (['.,])", r"\1", string)
+    return string
+
+
+def lowercase_first_letter(text):
+    return text[0].lower() + text[1:]
+
+
+def process_docs_paraphrases(dataset):
+    empty_docs = []
+
+    def _process_doc(doc):
+        if doc["sentence1"] not in [None, ""] and doc["sentence2"] not in [None, ""]:
+            doc["sentence1"] = general_detokenize(doc["sentence1"]).strip()
+            doc["sentence2"] = general_detokenize(doc["sentence2"]).strip()
+            # Remove final punctuation mark in the first sentence
+            if doc["sentence1"].endswith((".", ",", ";")):
+                doc["sentence1"] = doc["sentence1"][:-1]
+            # Start the second sentence in lowercase (to be used after "Yes, ...")
+            doc["sentence2"] = lowercase_first_letter(doc["sentence2"])
+            return doc
+        else:
+            empty_docs.append(doc)
+            return doc
+
+    if empty_docs != []:
+        len_empty_docs = len(empty_docs)
+        print(
+            f"Found {len_empty_docs} empty documents out of the {len(dataset)} total docs in the dataset: {empty_docs}"
+        )
+    return dataset.filter(
+        lambda doc: (
+            doc["sentence1"] not in [None, ""] and doc["sentence2"] not in [None, ""]
+        )
+    ).map(_process_doc)

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -474,6 +474,8 @@ task_groups:
       - task: pawsx_spa_Latn
         subset: es
       - task: pawsx_fra_Latn
+        subset: fr
+
   xnli-eu:
     description: "XNLI EU natural language inference (0-shot, acc)"
     suite: lm-eval-harness

--- a/oellm/resources/task-groups.yaml
+++ b/oellm/resources/task-groups.yaml
@@ -80,6 +80,10 @@ task_metrics:
   xcsqa_nld_Latn: acc_norm
   xcsqa_pol_Latn: acc_norm
   xcsqa_por_Latn: acc_norm
+  pawsx_deu_Latn: acc
+  pawsx_eng_Latn: acc
+  pawsx_spa_Latn: acc
+  pawsx_fra_Latn: acc
   copa: acc
   lambada_openai: acc
   openbookqa: acc_norm
@@ -450,6 +454,21 @@ task_groups:
         subset: X-CSQA-pl
       - task: xcsqa_por_Latn
         subset: X-CSQA-pt
+
+  pawsx-eu:
+    description: "PAWS-X EU paraphrase detection (0-shot, acc)"
+    suite: lm-eval-harness
+    n_shots: [0]
+    dataset: google-research-datasets/paws-x
+    tasks:
+      - task: pawsx_deu_Latn
+        subset: de
+      - task: pawsx_eng_Latn
+        subset: en
+      - task: pawsx_spa_Latn
+        subset: es
+      - task: pawsx_fra_Latn
+        subset: fr
 
   flores-200-eu-to-eng:
     description: "Flores 200 EU->English translation (0-shot, chrf++)."

--- a/tests/test_language_groups.py
+++ b/tests/test_language_groups.py
@@ -23,7 +23,7 @@ from oellm.task_groups import (
 
 # Multilingual groups still defined with explicit per-language task lists
 # (not {lang} templates) whose tasks must also resolve to a language.
-EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include", "xcsqa-eu"]
+EXPLICIT_MULTILINGUAL_GROUPS = ["mgsm-eu", "include", "xcsqa-eu", "pawsx-eu"]
 
 
 def _raw_yaml() -> dict:


### PR DESCRIPTION
## Summary

One of the evals from #89. Adds PAWS-X ([google-research-datasets/paws-x](https://huggingface.co/datasets/google-research-datasets/paws-x)) as a new `pawsx-eu` task group, restricted to the EU-language subset the dataset ships: **de, en, es, fr**.

## Implementation

Custom lm-eval-harness tasks under `oellm/resources/custom_lm_eval_tasks/pawsx/`, same rationale and structure as #105: identical prompt format to the harness's built-in paws-x tasks (localized cloze with `process_docs_paraphrases`, ported verbatim), but pointing at the canonical `google-research-datasets/paws-x` id — the built-ins still use the legacy bare `paws-x` id, which recent huggingface_hub versions reject and which cannot be resolved from a pre-downloaded cache on offline compute nodes. Task names use the `pawsx_<lang_Scri>` convention (built-ins are `paws_<iso1>`, so no clash), tag `pawsx_eu`.

0-shot, `acc` (log-prob choice scoring). Registered in `task-groups.yaml` with per-language `task_metrics` entries and added to the explicit multilingual groups in the tests.

## Testing

- Full unit test suite passes (100 tests), ruff check and format clean.
- Group expansion, `pawsx-eu[deu_Latn|fra_Latn]` bracket filtering, and dataset pre-download specs (`google-research-datasets/paws-x` × 4 configs) verified.
- End-to-end `lm_eval` run of `pawsx_deu_Latn` and `pawsx_fra_Latn` (pythia-14m, `--limit 8`) completes with chance-level accuracy as expected for a 14M model on binary paraphrase detection.